### PR TITLE
Added Net Worth to Simulator

### DIFF
--- a/src/world_builder/NET_WORTH_CONFIG.md
+++ b/src/world_builder/NET_WORTH_CONFIG.md
@@ -74,6 +74,47 @@ The configuration is defined in a JSON file with the following structure:
 
 ## Example Configurations
 
+### Constant Net Worth
+
+### Net Worth with Age
+
+The net worth configuration system models how a character's wealth evolves over time based on their profession and attributes. Each profession can have its own unique function that determines how net worth scales with these attributes.
+
+For example, a Sith's net worth might be constant regardless of age, as they are provided for by the Empire:
+
+```json
+{
+    "profession_net_worth": {
+        "Sith": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "constant",
+                "params": {
+                    "value": 10000
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "constant",
+                        "params": {
+                            "value": 1000
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "metadata": {
+        "currency": "imperial_credits"
+    }
+}
+```
+
+In this example, a Sith would have a mean net worth of 10,000 imperial credits with a standard deviation of 1,000 credits, regardless of their age.
+
 ### Linear Scaling with Age
 
 ```json

--- a/src/world_builder/NET_WORTH_CONFIG.md
+++ b/src/world_builder/NET_WORTH_CONFIG.md
@@ -1,0 +1,175 @@
+# Net Worth Configuration
+
+This document describes the configuration system for generating character net worth values in the world builder.
+
+## Overview
+
+The net worth configuration system models how a character's wealth evolves over time based on their profession and attributes. The core concept is that net worth follows a predictable trend over a character's lifetime (e.g., increasing with age or experience), but with natural variation at any given point in time. For example, a farmer's wealth might generally increase with age, but two 30-year-old farmers could have different net worths due to various factors like crop yields, market conditions, or personal circumstances.
+
+The system captures this by defining two components for each profession:
+1. A mean function that describes the expected wealth trend over time (e.g., linear growth with age)
+2. A noise function that adds realistic variation around this trend
+
+This approach allows us to generate realistic net worth distributions that reflect both the systematic progression of wealth in a profession and the natural variation we'd expect to see in real-world scenarios.
+
+The net worth configuration system uses function-based distributions to calculate a character's net worth based on their attributes (e.g., age, experience). Each profession can have its own unique function that determines how net worth scales with these attributes.
+
+## Configuration Structure
+
+The configuration is defined in a JSON file with the following structure:
+
+```json
+{
+    "profession_net_worth": {
+        "profession_name": {
+            "field_name": "attribute_name",
+            "mean_function": {
+                "type": "function_type",
+                "params": {
+                    // Function-specific parameters
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "attribute_name",
+                    "scale_factor": {
+                        "type": "function_type",
+                        "params": {
+                            // Function-specific parameters
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "metadata": {
+        "currency": "currency_type",
+        // Additional metadata fields
+    }
+}
+```
+
+### Components
+
+1. **profession_net_worth**: A dictionary mapping profession names to their net worth configurations.
+
+2. **field_name**: The character attribute to use for net worth calculation (e.g., "age", "experience").
+
+3. **mean_function**: Defines how the base net worth scales with the attribute.
+   - **type**: One of "linear", "exponential", or "quadratic"
+   - **params**: Parameters specific to the function type:
+     - Linear: `slope` and `intercept`
+     - Exponential: `base` and `rate`
+     - Quadratic: `a`, `b`, and `c`
+
+4. **noise_function**: Defines the random variation in net worth.
+   - **type**: Currently only supports "normal" distribution
+   - **params**:
+     - **field_name**: The attribute to use for scaling
+     - **scale_factor**: A function configuration that determines how the standard deviation scales with the attribute
+
+5. **metadata**: Optional metadata fields.
+   - **currency**: The type of currency (defaults to "credits")
+
+## Example Configurations
+
+### Linear Scaling with Age
+
+```json
+{
+    "profession_net_worth": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 5,
+                    "intercept": 100
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": {
+                            "slope": 0.1,
+                            "intercept": 0
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "metadata": {
+        "currency": "credits"
+    }
+}
+```
+
+In this example:
+- A 30-year-old farmer would have a mean net worth of 250 credits (5 * 30 + 100)
+- The standard deviation would be 3 credits (0.1 * 30 + 0)
+
+### Exponential Growth with Experience
+
+```json
+{
+    "profession_net_worth": {
+        "merchant": {
+            "field_name": "experience",
+            "mean_function": {
+                "type": "exponential",
+                "params": {
+                    "base": 50,
+                    "rate": 0.1
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "experience",
+                    "scale_factor": {
+                        "type": "quadratic",
+                        "params": {
+                            "a": 0.01,
+                            "b": 0,
+                            "c": 0
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+In this example:
+- A merchant with 5 years of experience would have a mean net worth of 82.4 credits (50 * e^(0.1 * 5))
+- The standard deviation would be 0.25 credits (0.01 * 5^2)
+
+## Implementation Details
+
+The net worth generation process:
+1. Gets the character's attribute value (e.g., age)
+2. Calculates the mean net worth using the mean_function
+3. Calculates the standard deviation using the noise_function's scale_factor
+4. Generates the final net worth by adding normally distributed noise
+5. Ensures the net worth is never negative
+
+## Best Practices
+
+1. **Mean Functions**:
+   - Use linear functions for steady growth
+   - Use exponential functions for accelerating growth
+   - Use quadratic functions for growth that accelerates then slows
+
+2. **Noise Functions**:
+   - Keep scale factors small relative to mean values
+   - Consider using quadratic scale factors for professions where wealth variation increases with experience
+
+3. **Field Selection**:
+   - Use "age" for professions where experience correlates with age
+   - Use "experience" for professions where experience can be gained independently of age 

--- a/src/world_builder/distributions_config.py
+++ b/src/world_builder/distributions_config.py
@@ -16,6 +16,12 @@ class FunctionParams(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
+class ConstantParams(FunctionParams):
+    """Parameters for constant function."""
+
+    value: float
+
+
 class LinearParams(FunctionParams):
     """Parameters for linear function."""
 
@@ -43,12 +49,14 @@ class FunctionConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    type: Literal["linear", "exponential", "quadratic"]
-    params: Union[LinearParams, ExponentialParams, QuadraticParams]
+    type: Literal["constant", "linear", "exponential", "quadratic"]
+    params: Union[ConstantParams, LinearParams, ExponentialParams, QuadraticParams]
 
     @model_validator(mode="after")
     def validate_params(self) -> "FunctionConfig":
         """Validate that params match the function type."""
+        if self.type == "constant" and not isinstance(self.params, ConstantParams):
+            raise ValueError("Constant function requires ConstantParams")
         if self.type == "linear" and not isinstance(self.params, LinearParams):
             raise ValueError("Linear function requires LinearParams")
         if self.type == "exponential" and not isinstance(

--- a/src/world_builder/distributions_config.py
+++ b/src/world_builder/distributions_config.py
@@ -18,12 +18,14 @@ class DistributionTransformOperation(BaseModel):
         mean_shift: Optional amount to shift the mean by (additive)
         std_mult: Optional amount to multiply the standard deviation by
     """
+
     mean_shift: float | None = None
     std_mult: float | None = None
 
 
 class TransformableDistribution(Protocol):
     """Protocol defining distributions that can be transformed."""
+
     def with_transform(
         self, transform: DistributionTransformOperation
     ) -> "TransformableDistribution":
@@ -48,6 +50,7 @@ class NormalDist(BaseModel):
         mean: Mean (μ) of the distribution
         std: Standard deviation (σ) of the distribution
     """
+
     type: Literal["normal"]
     mean: float
     std: float
@@ -79,6 +82,7 @@ class LogNormalDist(BaseModel):
         mean: Mean (μ) of the underlying normal distribution
         std: Standard deviation (σ) of the underlying normal distribution
     """
+
     type: Literal["lognormal"]
     mean: float
     std: float
@@ -114,6 +118,7 @@ class TruncatedNormalDist(BaseModel):
         lower: Lower bound (inclusive) for truncation
         upper: Upper bound (inclusive) for truncation, defaults to positive infinity
     """
+
     type: Literal["truncated_normal"]
     mean: float
     std: float

--- a/src/world_builder/distributions_config.py
+++ b/src/world_builder/distributions_config.py
@@ -77,8 +77,10 @@ class NoiseFunctionConfig(BaseModel):
             raise ValueError("Noise function must specify field_name")
         if "scale_factor" not in self.params:
             raise ValueError("Noise function must specify scale_factor")
-        if not isinstance(self.params["scale_factor"], dict):
+        if not isinstance(self.params["scale_factor"], (dict, FunctionConfig)):
             raise ValueError("scale_factor must be a function configuration")
+        if isinstance(self.params["scale_factor"], dict):
+            self.params["scale_factor"] = FunctionConfig(**self.params["scale_factor"])
         return self
 
 

--- a/src/world_builder/net_worth_config.py
+++ b/src/world_builder/net_worth_config.py
@@ -11,85 +11,49 @@ The config is a JSON file that contains the following fields:
 from typing import Dict
 import json
 from pathlib import Path
-import math
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
-from typing_extensions import Self
+from pydantic import BaseModel, ConfigDict, Field
 
-from world_builder.distributions_config import (
-    Distribution,
-    NormalDist,
-    LogNormalDist,
-    TruncatedNormalDist,
-)
+from world_builder.distributions_config import Distribution, FunctionBasedDist
 
 
 class NetWorthConfig(BaseModel):
     """
-    Loads the net worth config for the world into a Pydantic model.
+    Configuration for net worth generation.
+
+    Attributes:
+        profession_net_worth: Maps each profession to its net worth distribution
+        metadata: Optional metadata fields
     """
 
     model_config = ConfigDict(frozen=True)
 
     # Maps each profession to its net worth distribution
-    profession_net_worth: Dict[str, Distribution] = Field(
+    profession_net_worth: Dict[str, FunctionBasedDist] = Field(
         description="Required mapping of professions to their net worth distributions."
     )
 
     # catch-all dict for any miscellaneous, constant metadata fields
     metadata: Dict[str, str] = Field(
-        default_factory=dict,
-        description="Optional metadata fields. Can be used to store any string-like constants or metadata.",
+        default_factory=dict, description="Optional metadata fields."
     )
 
-    @model_validator(mode="after")
-    def validate_distributions(self) -> Self:
-        """
-        Validates that all distributions are valid.
-        """
-        for profession, dist in self.profession_net_worth.items():
-            if not isinstance(dist, Distribution):
-                raise ValueError(
-                    f"Invalid distribution for profession '{profession}': {dist}"
-                )
 
-            # Validate distribution-specific parameters
-            if isinstance(dist, (NormalDist, LogNormalDist)):
-                if dist.std <= 0:
-                    raise ValueError(
-                        f"Standard deviation must be positive for profession '{profession}'. Got {dist.std}"
-                    )
-                if math.isnan(dist.std) or math.isinf(dist.std):
-                    raise ValueError(
-                        f"Standard deviation must be finite for profession '{profession}'. Got {dist.std}"
-                    )
-            elif isinstance(dist, TruncatedNormalDist):
-                if dist.std <= 0:
-                    raise ValueError(
-                        f"Standard deviation must be positive for profession '{profession}'. Got {dist.std}"
-                    )
-                if math.isnan(dist.std) or math.isinf(dist.std):
-                    raise ValueError(
-                        f"Standard deviation must be finite for profession '{profession}'. Got {dist.std}"
-                    )
-                if dist.lower >= dist.upper:
-                    raise ValueError(
-                        f"Lower bound must be less than upper bound for profession '{profession}'. "
-                        f"Got lower={dist.lower}, upper={dist.upper}"
-                    )
-        return self
-
-
-def load_config(config_filepath: Path) -> NetWorthConfig:
+def load_config(config_path: Path) -> NetWorthConfig:
     """
-    Loads the JSON configuration file and validates each distribution.
+    Load the net worth configuration from a JSON file.
+
+    Args:
+        config_path: Path to the JSON configuration file
+
+    Returns:
+        A NetWorthConfig object containing the loaded configuration
+
+    Raises:
+        FileNotFoundError: If the config file doesn't exist
+        json.JSONDecodeError: If the config file isn't valid JSON
+        ValidationError: If the config doesn't match the expected schema
     """
-    with open(config_filepath, "r") as f:
-        try:
-            config_json = json.load(f)
-        except json.JSONDecodeError as e:
-            raise ValueError(
-                f"Tried to load {config_filepath} into JSON object and failed. Check to ensure it the file provided is valid JSON."
-            ) from e
-    net_worth_config = NetWorthConfig(**config_json)
-    return net_worth_config
+    with open(config_path) as f:
+        config_data = json.load(f)
+    return NetWorthConfig(**config_data)

--- a/src/world_builder/net_worth_config.py
+++ b/src/world_builder/net_worth_config.py
@@ -1,0 +1,95 @@
+"""
+Module for loading the net worth configuration.
+This module implements a basic helper function, load_config, to load the net worth configuration.
+This helper function returns a Pydantic model, which automatically validates the config.
+
+The config is a JSON file that contains the following fields:
+- profession_net_worth: a dictionary mapping professions to their net worth distributions
+- metadata: optional metadata fields
+"""
+
+from typing import Dict
+import json
+from pathlib import Path
+import math
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from typing_extensions import Self
+
+from world_builder.distributions_config import (
+    Distribution,
+    NormalDist,
+    LogNormalDist,
+    TruncatedNormalDist,
+)
+
+
+class NetWorthConfig(BaseModel):
+    """
+    Loads the net worth config for the world into a Pydantic model.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    # Maps each profession to its net worth distribution
+    profession_net_worth: Dict[str, Distribution] = Field(
+        description="Required mapping of professions to their net worth distributions."
+    )
+
+    # catch-all dict for any miscellaneous, constant metadata fields
+    metadata: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Optional metadata fields. Can be used to store any string-like constants or metadata.",
+    )
+
+    @model_validator(mode="after")
+    def validate_distributions(self) -> Self:
+        """
+        Validates that all distributions are valid.
+        """
+        for profession, dist in self.profession_net_worth.items():
+            if not isinstance(dist, Distribution):
+                raise ValueError(
+                    f"Invalid distribution for profession '{profession}': {dist}"
+                )
+
+            # Validate distribution-specific parameters
+            if isinstance(dist, (NormalDist, LogNormalDist)):
+                if dist.std <= 0:
+                    raise ValueError(
+                        f"Standard deviation must be positive for profession '{profession}'. Got {dist.std}"
+                    )
+                if math.isnan(dist.std) or math.isinf(dist.std):
+                    raise ValueError(
+                        f"Standard deviation must be finite for profession '{profession}'. Got {dist.std}"
+                    )
+            elif isinstance(dist, TruncatedNormalDist):
+                if dist.std <= 0:
+                    raise ValueError(
+                        f"Standard deviation must be positive for profession '{profession}'. Got {dist.std}"
+                    )
+                if math.isnan(dist.std) or math.isinf(dist.std):
+                    raise ValueError(
+                        f"Standard deviation must be finite for profession '{profession}'. Got {dist.std}"
+                    )
+                if dist.lower >= dist.upper:
+                    raise ValueError(
+                        f"Lower bound must be less than upper bound for profession '{profession}'. "
+                        f"Got lower={dist.lower}, upper={dist.upper}"
+                    )
+        return self
+
+
+def load_config(config_filepath: Path) -> NetWorthConfig:
+    """
+    Loads the JSON configuration file and validates each distribution.
+    """
+    with open(config_filepath, "r") as f:
+        try:
+            config_json = json.load(f)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                f"Tried to load {config_filepath} into JSON object and failed. Check to ensure it the file provided is valid JSON."
+            ) from e
+    net_worth_config = NetWorthConfig(**config_json)
+    return net_worth_config

--- a/src/world_builder/net_worth_generator.py
+++ b/src/world_builder/net_worth_generator.py
@@ -1,0 +1,85 @@
+"""
+Module for generating net worth values for characters based on their professions.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from world_builder.net_worth_config import NetWorthConfig
+from world_builder.distributions_config import sample_from_config
+from world_builder.character import Character
+
+
+class NetWorth:
+    """
+    Represents a character's net worth.
+
+    Attributes:
+        chain_code: The unique identifier for this net worth record
+        liquid_currency: The amount of liquid currency the character has
+        currency_type: The type of currency (e.g., "credits", "imperial_credits")
+    """
+
+    def __init__(self, chain_code: str, liquid_currency: float, currency_type: str):
+        self._chain_code = chain_code
+        self._liquid_currency = liquid_currency
+        self._currency_type = currency_type
+
+    @property
+    def chain_code(self) -> str:
+        return self._chain_code
+
+    @property
+    def liquid_currency(self) -> float:
+        return self._liquid_currency
+
+    @property
+    def currency_type(self) -> str:
+        return self._currency_type
+
+    def __repr__(self) -> str:
+        return f"NetWorth(chain_code={self.chain_code!r}, liquid_currency={self.liquid_currency}, currency_type={self.currency_type!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, NetWorth):
+            return NotImplemented
+        return (
+            self.chain_code == other.chain_code
+            and self.liquid_currency == other.liquid_currency
+            and self.currency_type == other.currency_type
+        )
+
+
+def generate_net_worth(character: Character, config: NetWorthConfig) -> NetWorth:
+    """
+    Generate a net worth value for a character based on their profession.
+
+    Args:
+        character: The character to generate net worth for
+        config: The net worth configuration containing profession-based distributions
+
+    Returns:
+        A NetWorth object with the generated values
+
+    Raises:
+        ValueError: If the character's profession is not found in the config
+    """
+    if character.profession not in config.profession_net_worth:
+        raise ValueError(
+            f"Character profession '{character.profession}' not found in net worth config"
+        )
+
+    # Get the distribution for this profession
+    dist_config = config.profession_net_worth[character.profession]
+
+    # Sample from the distribution
+    liquid_currency = sample_from_config(dist_config)
+
+    # Get currency type from metadata, defaulting to "credits" if not specified
+    currency_type = config.metadata.get("currency", "credits")
+
+    return NetWorth(
+        chain_code=character.chain_code,
+        liquid_currency=liquid_currency,
+        currency_type=currency_type,
+    )

--- a/src/world_builder/net_worth_generator.py
+++ b/src/world_builder/net_worth_generator.py
@@ -63,7 +63,9 @@ def evaluate_function(func_config: FunctionConfig, x: float) -> float:
     Returns:
         The function value at x
     """
-    if func_config.type == "linear":
+    if func_config.type == "constant":
+        return func_config.params.value
+    elif func_config.type == "linear":
         return func_config.params.slope * x + func_config.params.intercept
     elif func_config.type == "exponential":
         return func_config.params.base * math.exp(func_config.params.rate * x)

--- a/src/world_builder/net_worth_generator.py
+++ b/src/world_builder/net_worth_generator.py
@@ -3,11 +3,12 @@ Module for generating net worth values for characters based on their professions
 """
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Dict, Any
 import random
 import math
 
-from world_builder.net_worth_config import NetWorthConfig, FunctionConfig
+from world_builder.net_worth_config import NetWorthConfig
+from world_builder.distributions_config import FunctionConfig, FunctionBasedDist
 from world_builder.character import Character
 
 
@@ -105,9 +106,8 @@ def generate_net_worth(character: Character, config: NetWorthConfig) -> NetWorth
     mean_value = evaluate_function(prof_config.mean_function, field_value)
 
     # Calculate the standard deviation using the scale factor function
-    std_value = evaluate_function(
-        prof_config.noise_function.params["scale_factor"], field_value
-    )
+    scale_factor_config = prof_config.noise_function.params["scale_factor"]
+    std_value = evaluate_function(scale_factor_config, field_value)
 
     # Generate the final value by adding normal noise
     liquid_currency = mean_value + random.gauss(0, std_value)

--- a/test/world_builder/config/nw_config_micro.json
+++ b/test/world_builder/config/nw_config_micro.json
@@ -1,19 +1,21 @@
 {
     "profession_net_worth": {
         "farmer": {
-            "type": "normal",
-            "mean": 100,
-            "std": 20
-        },
-        "merchant": {
-            "type": "normal",
-            "mean": 500,
-            "std": 100
-        },
-        "smuggler": {
-            "type": "lognormal",
-            "mean": 3.0,
-            "std": 1.0
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 5, "intercept": 100 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 0.1, "intercept": 0 }
+                    }
+                }
+            }
         }
     },
     "metadata": {

--- a/test/world_builder/config/nw_config_micro.json
+++ b/test/world_builder/config/nw_config_micro.json
@@ -1,0 +1,23 @@
+{
+    "profession_net_worth": {
+        "farmer": {
+            "type": "normal",
+            "mean": 100,
+            "std": 20
+        },
+        "merchant": {
+            "type": "normal",
+            "mean": 500,
+            "std": 100
+        },
+        "smuggler": {
+            "type": "lognormal",
+            "mean": 3.0,
+            "std": 1.0
+        }
+    },
+    "metadata": {
+        "currency": "credits",
+        "era": "Clone Wars"
+    }
+}

--- a/test/world_builder/config/nw_config_micro_jedi.json
+++ b/test/world_builder/config/nw_config_micro_jedi.json
@@ -3,10 +3,9 @@
         "Jedi": {
             "field_name": "age",
             "mean_function": {
-                "type": "linear",
+                "type": "constant",
                 "params": {
-                    "slope": 20,
-                    "intercept": 400
+                    "value": 1000
                 }
             },
             "noise_function": {
@@ -14,10 +13,9 @@
                 "params": {
                     "field_name": "age",
                     "scale_factor": {
-                        "type": "linear",
+                        "type": "constant",
                         "params": {
-                            "slope": 2,
-                            "intercept": 0
+                            "value": 100
                         }
                     }
                 }

--- a/test/world_builder/config/nw_config_micro_jedi.json
+++ b/test/world_builder/config/nw_config_micro_jedi.json
@@ -1,9 +1,27 @@
 {
     "profession_net_worth": {
         "Jedi": {
-            "type": "normal",
-            "mean": 1000,
-            "std": 200
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 20,
+                    "intercept": 400
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": {
+                            "slope": 2,
+                            "intercept": 0
+                        }
+                    }
+                }
+            }
         }
     },
     "metadata": {

--- a/test/world_builder/config/nw_config_micro_jedi.json
+++ b/test/world_builder/config/nw_config_micro_jedi.json
@@ -1,0 +1,13 @@
+{
+    "profession_net_worth": {
+        "Jedi": {
+            "type": "normal",
+            "mean": 1000,
+            "std": 200
+        }
+    },
+    "metadata": {
+        "currency": "credits",
+        "era": "Clone Wars"
+    }
+} 

--- a/test/world_builder/smoke/test_basic_config.py
+++ b/test/world_builder/smoke/test_basic_config.py
@@ -40,13 +40,6 @@ def test_micro_config():
         assert isinstance(net_worth.liquid_currency, float)
         assert net_worth.currency_type == "credits"
 
-        # Calculate expected mean based on age
-        expected_mean = 20 * character.age + 400
-        # Calculate expected std based on age
-        expected_std = 2 * character.age
-
-        # Verify that the net worth is within reasonable bounds
-        # Using 5 standard deviations as a reasonable bound
-        lower_bound = max(0, expected_mean - 5 * expected_std)
-        upper_bound = expected_mean + 5 * expected_std
-        assert lower_bound <= net_worth.liquid_currency <= upper_bound
+        # With constant functions, mean is 1000 and std is 100
+        # Allow for 5 standard deviations of variation
+        assert 500 <= net_worth.liquid_currency <= 1500

--- a/test/world_builder/smoke/test_basic_config.py
+++ b/test/world_builder/smoke/test_basic_config.py
@@ -1,26 +1,44 @@
 from pathlib import Path
 
 from world_builder import load_config, create_character
+from world_builder.net_worth_config import load_config as load_net_worth_config
+from world_builder.net_worth_generator import generate_net_worth
 
 
 def test_micro_config():
     """
     Smoke test for the world_builder module.
     Tests the world_builder module with a micro configuration file.
+    Also tests net worth generation for each character.
     """
     current_dir = Path(__file__).resolve().parent.parent
     config_dir = current_dir / "config"
 
-    CONFIG_FILE = config_dir / "wb_config_micro.json"
+    # Load population config
+    POPULATION_CONFIG = config_dir / "wb_config_micro.json"
     POPULATION_SIZE = 10
 
-    # loading the config takes some logic as well
-    # so this will also smoke if something is broken in load_config
-    config = load_config(CONFIG_FILE)
+    # Load net worth config
+    NET_WORTH_CONFIG = config_dir / "nw_config_micro_jedi.json"
 
-    # we just want to run the create_character function for the population size
-    # if it smokes here, that means something is fried inside
-    # if it doesn't smoke -- and we get the expected number of objects -- then the test passes
-    population = [create_character(config) for _ in range(POPULATION_SIZE)]
+    # Load both configs
+    population_config = load_config(POPULATION_CONFIG)
+    net_worth_config = load_net_worth_config(NET_WORTH_CONFIG)
 
+    # Generate population
+    population = [create_character(population_config) for _ in range(POPULATION_SIZE)]
     assert len(population) == POPULATION_SIZE
+
+    # Generate net worth for each character
+    net_worths = [
+        generate_net_worth(character, net_worth_config) for character in population
+    ]
+    assert len(net_worths) == POPULATION_SIZE
+
+    # Verify net worth properties
+    for net_worth in net_worths:
+        assert isinstance(net_worth.liquid_currency, float)
+        assert net_worth.currency_type == "credits"
+        # Verify that the net worth is within reasonable bounds for a Jedi
+        # Using 5 standard deviations as a reasonable bound
+        assert 400 <= net_worth.liquid_currency <= 1600  # mean ± 5*std

--- a/test/world_builder/smoke/test_basic_config.py
+++ b/test/world_builder/smoke/test_basic_config.py
@@ -36,9 +36,17 @@ def test_micro_config():
     assert len(net_worths) == POPULATION_SIZE
 
     # Verify net worth properties
-    for net_worth in net_worths:
+    for character, net_worth in zip(population, net_worths):
         assert isinstance(net_worth.liquid_currency, float)
         assert net_worth.currency_type == "credits"
-        # Verify that the net worth is within reasonable bounds for a Jedi
+
+        # Calculate expected mean based on age
+        expected_mean = 20 * character.age + 400
+        # Calculate expected std based on age
+        expected_std = 2 * character.age
+
+        # Verify that the net worth is within reasonable bounds
         # Using 5 standard deviations as a reasonable bound
-        assert 400 <= net_worth.liquid_currency <= 1600  # mean ± 5*std
+        lower_bound = max(0, expected_mean - 5 * expected_std)
+        upper_bound = expected_mean + 5 * expected_std
+        assert lower_bound <= net_worth.liquid_currency <= upper_bound

--- a/test/world_builder/test_net_worth_config.py
+++ b/test/world_builder/test_net_worth_config.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from world_builder.net_worth_config import load_config, NetWorthConfig
+from world_builder.distributions_config import (
+    Distribution,
+    NormalDist,
+    LogNormalDist,
+    TruncatedNormalDist,
+)
+
+parent_dir = Path(__file__).resolve().parent
+CONFIG_DIR = parent_dir / "config"
+CONFIG_FILE = CONFIG_DIR / "nw_config_micro.json"
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "nw_config_micro.json",
+    ],  # known good configs -- should pass
+)
+def test_load_config_smoke(filename):
+    """
+    Smoke test: ensure that loading a known good config file works without errors.
+    """
+    config_path = CONFIG_DIR / filename
+    config = load_config(config_path)
+    assert config is not None
+
+
+# Valid configurations should use the new schema keys:
+good_configs = [
+    # test for basic normal distribution
+    {
+        "profession_net_worth": {
+            "farmer": {"type": "normal", "mean": 100, "std": 20},
+            "merchant": {"type": "normal", "mean": 500, "std": 100},
+        },
+        "metadata": {"currency": "credits"},
+    },
+    # test for mixed distribution types
+    {
+        "profession_net_worth": {
+            "smuggler": {"type": "lognormal", "mean": 3.0, "std": 1.0},
+            "bounty_hunter": {
+                "type": "truncated_normal",
+                "mean": 1000,
+                "std": 200,
+                "lower": 0,
+            },
+            "jedi": {"type": "normal", "mean": 50, "std": 10},
+        },
+        "metadata": {"currency": "credits", "era": "Clone Wars"},
+    },
+]
+
+# Invalid configurations should trigger validation errors:
+bad_configs = [
+    # invalid distribution type
+    {
+        "profession_net_worth": {
+            "farmer": {"type": "invalid", "mean": 100, "std": 20},
+        },
+        "metadata": {"currency": "credits"},
+    },
+    # missing required distribution parameters
+    {
+        "profession_net_worth": {
+            "merchant": {"type": "normal", "mean": 500},  # missing std
+        },
+        "metadata": {"currency": "credits"},
+    },
+    # negative standard deviation
+    {
+        "profession_net_worth": {
+            "farmer": {"type": "normal", "mean": 100, "std": -20},
+        },
+        "metadata": {"currency": "credits"},
+    },
+]
+
+
+@pytest.mark.parametrize("config_data", good_configs)
+def test_networthconfig_valid(config_data):
+    """
+    Valid NetWorthConfig data should instantiate without errors,
+    and retain the correct structure.
+    """
+    config = NetWorthConfig(**config_data)
+    # Check that distributions are loaded correctly
+    assert set(config.profession_net_worth.keys()) == set(
+        config_data["profession_net_worth"].keys()
+    )
+    for profession, dist in config.profession_net_worth.items():
+        assert isinstance(dist, Distribution)
+    # Check metadata
+    if "metadata" in config_data:
+        assert config.metadata == config_data["metadata"]
+
+
+@pytest.mark.parametrize("config_data", bad_configs)
+def test_networthconfig_invalid(config_data):
+    """
+    Invalid NetWorthConfig data should raise a ValidationError.
+    """
+    with pytest.raises(ValidationError):
+        NetWorthConfig(**config_data)
+
+
+def test_distribution_types():
+    """
+    Test that different distribution types are properly handled.
+    """
+    config = NetWorthConfig(
+        profession_net_worth={
+            "normal": NormalDist(type="normal", mean=100, std=20),
+            "lognormal": LogNormalDist(type="lognormal", mean=3.0, std=1.0),
+            "truncated": TruncatedNormalDist(
+                type="truncated_normal", mean=1000, std=200, lower=0
+            ),
+        },
+        metadata={"test": "test"},
+    )
+
+    assert isinstance(config.profession_net_worth["normal"], NormalDist)
+    assert isinstance(config.profession_net_worth["lognormal"], LogNormalDist)
+    assert isinstance(config.profession_net_worth["truncated"], TruncatedNormalDist)

--- a/test/world_builder/test_net_worth_generator.py
+++ b/test/world_builder/test_net_worth_generator.py
@@ -1,0 +1,135 @@
+"""
+Tests for the net worth generator module.
+"""
+
+import pytest
+from dataclasses import dataclass
+
+from world_builder.net_worth_generator import NetWorth, generate_net_worth
+from world_builder.net_worth_config import NetWorthConfig
+from world_builder.distributions_config import NormalDist
+
+
+@dataclass
+class MockCharacter:
+    """Mock Character class for testing."""
+
+    chain_code: str
+    profession: str
+
+
+def test_networth_creation():
+    """Test that NetWorth objects can be created with valid data."""
+    net_worth = NetWorth(
+        chain_code="TEST123", liquid_currency=1000.0, currency_type="credits"
+    )
+
+    assert net_worth.chain_code == "TEST123"
+    assert net_worth.liquid_currency == 1000.0
+    assert net_worth.currency_type == "credits"
+
+
+def test_networth_immutability():
+    """Test that NetWorth objects are immutable through properties."""
+    net_worth = NetWorth(
+        chain_code="TEST123", liquid_currency=1000.0, currency_type="credits"
+    )
+
+    # Test that we can't set attributes directly
+    with pytest.raises(AttributeError):
+        net_worth.chain_code = "NEW123"
+    with pytest.raises(AttributeError):
+        net_worth.liquid_currency = 2000.0
+    with pytest.raises(AttributeError):
+        net_worth.currency_type = "imperial_credits"
+
+
+def test_networth_equality():
+    """Test that NetWorth objects can be compared for equality."""
+    net_worth1 = NetWorth(
+        chain_code="TEST123", liquid_currency=1000.0, currency_type="credits"
+    )
+
+    net_worth2 = NetWorth(
+        chain_code="TEST123", liquid_currency=1000.0, currency_type="credits"
+    )
+
+    net_worth3 = NetWorth(
+        chain_code="TEST456", liquid_currency=1000.0, currency_type="credits"
+    )
+
+    assert net_worth1 == net_worth2
+    assert net_worth1 != net_worth3
+    assert net_worth1 != "not a NetWorth object"
+
+
+def test_networth_repr():
+    """Test the string representation of NetWorth objects."""
+    net_worth = NetWorth(
+        chain_code="TEST123", liquid_currency=1000.0, currency_type="credits"
+    )
+
+    expected_repr = "NetWorth(chain_code='TEST123', liquid_currency=1000.0, currency_type='credits')"
+    assert repr(net_worth) == expected_repr
+
+
+def test_generate_net_worth_basic():
+    """Test basic net worth generation with a simple normal distribution."""
+    # Create a mock character
+    character = MockCharacter(chain_code="TEST123", profession="farmer")
+
+    # Create a simple config with one profession
+    config = NetWorthConfig(
+        profession_net_worth={"farmer": NormalDist(type="normal", mean=100, std=20)},
+        metadata={"currency": "credits"},
+    )
+
+    # Generate net worth
+    net_worth = generate_net_worth(character, config)
+
+    # Verify the result
+    assert net_worth.chain_code == "TEST123"
+    assert isinstance(net_worth.liquid_currency, float)
+    assert net_worth.currency_type == "credits"
+
+
+def test_generate_net_worth_unknown_profession():
+    """Test that generating net worth for an unknown profession raises an error."""
+    character = MockCharacter(chain_code="TEST123", profession="unknown_profession")
+
+    config = NetWorthConfig(
+        profession_net_worth={"farmer": NormalDist(type="normal", mean=100, std=20)},
+        metadata={"currency": "credits"},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Character profession 'unknown_profession' not found in net worth config",
+    ):
+        generate_net_worth(character, config)
+
+
+def test_generate_net_worth_default_currency():
+    """Test that net worth generation uses default currency when not specified in config."""
+    character = MockCharacter(chain_code="TEST123", profession="farmer")
+
+    config = NetWorthConfig(
+        profession_net_worth={"farmer": NormalDist(type="normal", mean=100, std=20)},
+        metadata={},  # No currency specified
+    )
+
+    net_worth = generate_net_worth(character, config)
+    assert net_worth.currency_type == "credits"  # Should use default
+
+
+def test_generate_net_worth_custom_currency():
+    """Test that net worth generation uses custom currency from config."""
+    character = MockCharacter(chain_code="TEST123", profession="farmer")
+
+    config = NetWorthConfig(
+        profession_net_worth={"farmer": NormalDist(type="normal", mean=100, std=20)},
+        metadata={"currency": "imperial_credits"},
+    )
+
+    net_worth = generate_net_worth(character, config)
+    assert net_worth.currency_type == "imperial_credits"

--- a/test/world_builder/test_net_worth_generator.py
+++ b/test/world_builder/test_net_worth_generator.py
@@ -8,7 +8,14 @@ from pathlib import Path
 
 from world_builder.net_worth_generator import NetWorth, generate_net_worth
 from world_builder.net_worth_config import NetWorthConfig, load_config
-from world_builder.distributions_config import NormalDist
+from world_builder.distributions_config import (
+    FunctionBasedDist,
+    FunctionConfig,
+    NoiseFunctionConfig,
+    LinearParams,
+    ExponentialParams,
+    QuadraticParams,
+)
 from world_builder.character import Character
 
 
@@ -18,6 +25,7 @@ class MockCharacter:
 
     chain_code: str
     profession: str
+    age: int = 30  # Default age for testing
 
 
 def test_networth_creation():
@@ -76,13 +84,29 @@ def test_networth_repr():
 
 
 def test_generate_net_worth_basic():
-    """Test basic net worth generation with a simple normal distribution."""
+    """Test basic net worth generation with a simple function-based distribution."""
     # Create a mock character
-    character = MockCharacter(chain_code="TEST123", profession="farmer")
+    character = MockCharacter(chain_code="TEST123", profession="farmer", age=30)
 
     # Create a simple config with one profession
     config = NetWorthConfig(
-        profession_net_worth={"farmer": NormalDist(type="normal", mean=100, std=20)},
+        profession_net_worth={
+            "farmer": FunctionBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=5, intercept=100)
+                ),
+                noise_function=NoiseFunctionConfig(
+                    type="normal",
+                    params={
+                        "field_name": "age",
+                        "scale_factor": FunctionConfig(
+                            type="linear", params=LinearParams(slope=0.1, intercept=0)
+                        ),
+                    },
+                ),
+            )
+        },
         metadata={"currency": "credits"},
     )
 
@@ -93,6 +117,8 @@ def test_generate_net_worth_basic():
     assert net_worth.chain_code == "TEST123"
     assert isinstance(net_worth.liquid_currency, float)
     assert net_worth.currency_type == "credits"
+    # For age=30, mean should be 5*30 + 100 = 250
+    assert 150 <= net_worth.liquid_currency <= 350  # mean ± 100
 
 
 def test_generate_net_worth_unknown_profession():
@@ -100,7 +126,23 @@ def test_generate_net_worth_unknown_profession():
     character = MockCharacter(chain_code="TEST123", profession="unknown_profession")
 
     config = NetWorthConfig(
-        profession_net_worth={"farmer": NormalDist(type="normal", mean=100, std=20)},
+        profession_net_worth={
+            "farmer": FunctionBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=5, intercept=100)
+                ),
+                noise_function=NoiseFunctionConfig(
+                    type="normal",
+                    params={
+                        "field_name": "age",
+                        "scale_factor": FunctionConfig(
+                            type="linear", params=LinearParams(slope=0.1, intercept=0)
+                        ),
+                    },
+                ),
+            )
+        },
         metadata={"currency": "credits"},
     )
 
@@ -116,7 +158,23 @@ def test_generate_net_worth_default_currency():
     character = MockCharacter(chain_code="TEST123", profession="farmer")
 
     config = NetWorthConfig(
-        profession_net_worth={"farmer": NormalDist(type="normal", mean=100, std=20)},
+        profession_net_worth={
+            "farmer": FunctionBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=5, intercept=100)
+                ),
+                noise_function=NoiseFunctionConfig(
+                    type="normal",
+                    params={
+                        "field_name": "age",
+                        "scale_factor": FunctionConfig(
+                            type="linear", params=LinearParams(slope=0.1, intercept=0)
+                        ),
+                    },
+                ),
+            )
+        },
         metadata={},  # No currency specified
     )
 
@@ -129,7 +187,23 @@ def test_generate_net_worth_custom_currency():
     character = MockCharacter(chain_code="TEST123", profession="farmer")
 
     config = NetWorthConfig(
-        profession_net_worth={"farmer": NormalDist(type="normal", mean=100, std=20)},
+        profession_net_worth={
+            "farmer": FunctionBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=5, intercept=100)
+                ),
+                noise_function=NoiseFunctionConfig(
+                    type="normal",
+                    params={
+                        "field_name": "age",
+                        "scale_factor": FunctionConfig(
+                            type="linear", params=LinearParams(slope=0.1, intercept=0)
+                        ),
+                    },
+                ),
+            )
+        },
         metadata={"currency": "imperial_credits"},
     )
 

--- a/test/world_builder/test_net_worth_generator.py
+++ b/test/world_builder/test_net_worth_generator.py
@@ -4,10 +4,12 @@ Tests for the net worth generator module.
 
 import pytest
 from dataclasses import dataclass
+from pathlib import Path
 
 from world_builder.net_worth_generator import NetWorth, generate_net_worth
-from world_builder.net_worth_config import NetWorthConfig
+from world_builder.net_worth_config import NetWorthConfig, load_config
 from world_builder.distributions_config import NormalDist
+from world_builder.character import Character
 
 
 @dataclass
@@ -133,3 +135,26 @@ def test_generate_net_worth_custom_currency():
 
     net_worth = generate_net_worth(character, config)
     assert net_worth.currency_type == "imperial_credits"
+
+
+def test_generate_net_worth_from_file():
+    """Test the full net worth generation process using a real Character and config file."""
+    # Create a real character
+    character = Character(
+        species="human",
+        age=30,
+        profession="farmer",
+        chain_code="TEST123",
+    )
+
+    # Load config from file
+    config_path = Path(__file__).parent / "config" / "nw_config_micro.json"
+    config = load_config(config_path)
+
+    # Generate net worth
+    net_worth = generate_net_worth(character, config)
+
+    # Verify the result
+    assert net_worth.chain_code == "TEST123"
+    assert isinstance(net_worth.liquid_currency, float)
+    assert net_worth.currency_type == "credits"


### PR DESCRIPTION
This feature adds net worth. In particular, given a character and a NetWorthConfig object, we are able to generate a character's net worth, drawing from a distribution centered around the trajectory of their profession + another factor (say, age).