### PR TITLE
Feature add new fields net worth

### DIFF
--- a/examples/world_builder/example_net_worth.py
+++ b/examples/world_builder/example_net_worth.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from world_builder.character import Character
+from world_builder.net_worth_generator import generate_net_worth
+from world_builder.net_worth_config import NetWorthConfig, load_config
+
+example_character = Character(
+    species="human",
+    age=30,
+    profession="farmer",
+    chain_code="TEST123",
+)
+
+file_path = Path(__file__).parent / "example_net_worth_config.json"
+
+net_worth_config = load_config(file_path)
+
+net_worth = generate_net_worth(example_character, net_worth_config)
+print(net_worth)

--- a/examples/world_builder/example_net_worth_config.json
+++ b/examples/world_builder/example_net_worth_config.json
@@ -1,0 +1,53 @@
+{
+    "profession_liquid_currency": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 5, "intercept": 100 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 0.1, "intercept": 0 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_primary_residence": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.02, "intercept": 0.1 }
+            }
+        }
+    },
+    "profession_primary_residence_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 1000, "intercept": 50000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 100, "intercept": 5000 }
+                    }
+                }
+            }
+        }
+    },
+    "metadata": {
+        "currency": "credits",
+        "era": "Clone Wars"
+    }
+}

--- a/examples/world_builder/example_net_worth_config.json
+++ b/examples/world_builder/example_net_worth_config.json
@@ -18,225 +18,229 @@
             }
         }
     },
-    "profession_has_primary_residence": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.02, "intercept": 0.1 }
+    "profession_has": {
+        "primary_residence": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.02, "intercept": 0.1 }
+                }
             }
-        }
-    },
-    "profession_primary_residence_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 1000, "intercept": 50000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 100, "intercept": 5000 }
-                    }
+        },
+        "other_properties": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.01, "intercept": 0.05 }
+                }
+            }
+        },
+        "starships": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.005, "intercept": 0.01 }
+                }
+            }
+        },
+        "speeders": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.015, "intercept": 0.05 }
+                }
+            }
+        },
+        "other_vehicles": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.01, "intercept": 0.03 }
+                }
+            }
+        },
+        "luxury_property": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.008, "intercept": 0.02 }
+                }
+            }
+        },
+        "galactic_stock": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.012, "intercept": 0.04 }
+                }
+            }
+        },
+        "business": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.01, "intercept": 0.03 }
                 }
             }
         }
     },
-    "profession_has_other_properties": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.01, "intercept": 0.05 }
-            }
-        }
-    },
-    "profession_other_properties_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 500, "intercept": 25000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 50, "intercept": 2500 }
+    "profession_value": {
+        "primary_residence": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 1000, "intercept": 50000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 100, "intercept": 5000 }
+                        }
                     }
                 }
             }
-        }
-    },
-    "profession_has_starships": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.005, "intercept": 0.01 }
-            }
-        }
-    },
-    "profession_starships_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 2000, "intercept": 100000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 200, "intercept": 10000 }
+        },
+        "other_properties": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 500, "intercept": 25000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 50, "intercept": 2500 }
+                        }
                     }
                 }
             }
-        }
-    },
-    "profession_has_speeders": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.015, "intercept": 0.05 }
-            }
-        }
-    },
-    "profession_speeders_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 300, "intercept": 15000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 30, "intercept": 1500 }
+        },
+        "starships": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 2000, "intercept": 100000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 200, "intercept": 10000 }
+                        }
                     }
                 }
             }
-        }
-    },
-    "profession_has_other_vehicles": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.01, "intercept": 0.03 }
-            }
-        }
-    },
-    "profession_other_vehicles_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 400, "intercept": 20000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 40, "intercept": 2000 }
+        },
+        "speeders": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 300, "intercept": 15000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 30, "intercept": 1500 }
+                        }
                     }
                 }
             }
-        }
-    },
-    "profession_has_luxury_property": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.008, "intercept": 0.02 }
-            }
-        }
-    },
-    "profession_luxury_property_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 3000, "intercept": 150000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 300, "intercept": 15000 }
+        },
+        "other_vehicles": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 400, "intercept": 20000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 40, "intercept": 2000 }
+                        }
                     }
                 }
             }
-        }
-    },
-    "profession_has_galactic_stock": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.012, "intercept": 0.04 }
-            }
-        }
-    },
-    "profession_galactic_stock_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 800, "intercept": 40000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 80, "intercept": 4000 }
+        },
+        "luxury_property": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 3000, "intercept": 150000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 300, "intercept": 15000 }
+                        }
                     }
                 }
             }
-        }
-    },
-    "profession_has_business": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.01, "intercept": 0.03 }
+        },
+        "galactic_stock": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 800, "intercept": 40000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 80, "intercept": 4000 }
+                        }
+                    }
+                }
             }
-        }
-    },
-    "profession_business_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 2500, "intercept": 125000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 250, "intercept": 12500 }
+        },
+        "business": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 2500, "intercept": 125000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 250, "intercept": 12500 }
+                        }
                     }
                 }
             }

--- a/examples/world_builder/example_net_worth_config.json
+++ b/examples/world_builder/example_net_worth_config.json
@@ -46,6 +46,202 @@
             }
         }
     },
+    "profession_has_other_properties": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.01, "intercept": 0.05 }
+            }
+        }
+    },
+    "profession_other_properties_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 500, "intercept": 25000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 50, "intercept": 2500 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_starships": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.005, "intercept": 0.01 }
+            }
+        }
+    },
+    "profession_starships_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 2000, "intercept": 100000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 200, "intercept": 10000 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_speeders": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.015, "intercept": 0.05 }
+            }
+        }
+    },
+    "profession_speeders_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 300, "intercept": 15000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 30, "intercept": 1500 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_other_vehicles": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.01, "intercept": 0.03 }
+            }
+        }
+    },
+    "profession_other_vehicles_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 400, "intercept": 20000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 40, "intercept": 2000 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_luxury_property": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.008, "intercept": 0.02 }
+            }
+        }
+    },
+    "profession_luxury_property_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 3000, "intercept": 150000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 300, "intercept": 15000 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_galactic_stock": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.012, "intercept": 0.04 }
+            }
+        }
+    },
+    "profession_galactic_stock_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 800, "intercept": 40000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 80, "intercept": 4000 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_business": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.01, "intercept": 0.03 }
+            }
+        }
+    },
+    "profession_business_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 2500, "intercept": 125000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 250, "intercept": 12500 }
+                    }
+                }
+            }
+        }
+    },
     "metadata": {
         "currency": "credits",
         "era": "Clone Wars"

--- a/src/world_builder/NET_WORTH_CONFIG.md
+++ b/src/world_builder/NET_WORTH_CONFIG.md
@@ -8,10 +8,12 @@ The net worth configuration file is a JSON file that defines how net worth value
 
 ## Configuration Format
 
-The configuration file has two main sections:
+The configuration file has four main sections:
 
 1. `profession_liquid_currency`: Defines the net worth generation rules for each profession
-2. `metadata`: Contains additional configuration metadata
+2. `profession_has_primary_residence`: Optional section defining the probability of owning a primary residence for each profession
+3. `profession_primary_residence_value`: Optional section defining the value distribution for owned primary residences
+4. `metadata`: Contains additional configuration metadata
 
 ### Example Configuration
 
@@ -42,6 +44,43 @@ The configuration file has two main sections:
             }
         }
     },
+    "profession_has_primary_residence": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 0.02,
+                    "intercept": 0.1
+                }
+            }
+        }
+    },
+    "profession_primary_residence_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 1000,
+                    "intercept": 50000
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": {
+                            "slope": 100,
+                            "intercept": 5000
+                        }
+                    }
+                }
+            }
+        }
+    },
     "metadata": {
         "currency": "credits",
         "era": "Clone Wars"
@@ -57,7 +96,20 @@ The configuration file has two main sections:
    - `mean_function`: Function configuration for the mean value
    - `noise_function`: Function configuration for the noise/variation
 
-2. **metadata**: Optional metadata fields
+2. **profession_has_primary_residence**: Optional dictionary mapping professions to their probability of owning a primary residence.
+   Each profession entry contains:
+   - `field_name`: The character attribute to use (e.g., "age")
+   - `mean_function`: Function configuration that outputs a probability between 0 and 1
+   The output probability determines whether a character owns a primary residence.
+
+3. **profession_primary_residence_value**: Optional dictionary mapping professions to their residence value distributions.
+   Each profession entry follows the same format as `profession_liquid_currency`, containing:
+   - `field_name`: The character attribute to use (e.g., "age")
+   - `mean_function`: Function configuration for the mean residence value
+   - `noise_function`: Function configuration for the value variation
+   This distribution is only used if the character owns a primary residence.
+
+4. **metadata**: Optional metadata fields
    - `currency`: The currency type (defaults to "credits")
    - `era`: The era this configuration is for
 
@@ -139,6 +191,43 @@ The configuration supports several function types for both mean and noise calcul
             }
         }
     },
+    "profession_has_primary_residence": {
+        "merchant": {
+            "field_name": "experience",
+            "mean_function": {
+                "type": "exponential",
+                "params": {
+                    "base": 0.2,
+                    "rate": 0.05
+                }
+            }
+        }
+    },
+    "profession_primary_residence_value": {
+        "merchant": {
+            "field_name": "experience",
+            "mean_function": {
+                "type": "exponential",
+                "params": {
+                    "base": 100000,
+                    "rate": 0.05
+                }
+            },
+            "noise_function": {
+                "type": "lognormal",
+                "params": {
+                    "field_name": "experience",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": {
+                            "slope": 1000,
+                            "intercept": 10000
+                        }
+                    }
+                }
+            }
+        }
+    },
     "metadata": {
         "currency": "credits"
     }
@@ -150,4 +239,6 @@ The configuration supports several function types for both mean and noise calcul
 1. All monetary values are in the specified currency units (defaults to "credits")
 2. Functions can use any numeric character attribute (age, experience, etc.)
 3. Noise functions support normal, lognormal, and truncated normal distributions
-4. The configuration is validated when loaded to ensure all required fields are present 
+4. The configuration is validated when loaded to ensure all required fields are present
+5. Primary residence ownership is determined by a Bernoulli trial using the probability from `profession_has_primary_residence`
+6. Primary residence value is only generated if a character owns a primary residence 

--- a/src/world_builder/NET_WORTH_CONFIG.md
+++ b/src/world_builder/NET_WORTH_CONFIG.md
@@ -8,12 +8,26 @@ The net worth configuration file is a JSON file that defines how net worth value
 
 ## Configuration Format
 
-The configuration file has four main sections:
+The configuration file has the following main sections:
 
 1. `profession_liquid_currency`: Defines the net worth generation rules for each profession
 2. `profession_has_primary_residence`: Optional section defining the probability of owning a primary residence for each profession
 3. `profession_primary_residence_value`: Optional section defining the value distribution for owned primary residences
-4. `metadata`: Contains additional configuration metadata
+4. `profession_has_other_properties`: Optional section defining the probability of owning other properties for each profession
+5. `profession_other_properties_net_value`: Optional section defining the value distribution for owned other properties
+6. `profession_has_starships`: Optional section defining the probability of owning starships for each profession
+7. `profession_starships_net_value`: Optional section defining the value distribution for owned starships
+8. `profession_has_speeders`: Optional section defining the probability of owning speeders for each profession
+9. `profession_speeders_net_value`: Optional section defining the value distribution for owned speeders
+10. `profession_has_other_vehicles`: Optional section defining the probability of owning other vehicles for each profession
+11. `profession_other_vehicles_net_value`: Optional section defining the value distribution for owned other vehicles
+12. `profession_has_luxury_property`: Optional section defining the probability of owning luxury property for each profession
+13. `profession_luxury_property_net_value`: Optional section defining the value distribution for owned luxury property
+14. `profession_has_galactic_stock`: Optional section defining the probability of owning galactic stock for each profession
+15. `profession_galactic_stock_net_value`: Optional section defining the value distribution for owned galactic stock
+16. `profession_has_business`: Optional section defining the probability of owning a business for each profession
+17. `profession_business_net_value`: Optional section defining the value distribution for owned businesses
+18. `metadata`: Contains additional configuration metadata
 
 ### Example Configuration
 
@@ -81,6 +95,265 @@ The configuration file has four main sections:
             }
         }
     },
+    "profession_has_other_properties": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 0.01,
+                    "intercept": 0.05
+                }
+            }
+        }
+    },
+    "profession_other_properties_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 500,
+                    "intercept": 25000
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": {
+                            "slope": 50,
+                            "intercept": 2500
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_starships": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 0.005,
+                    "intercept": 0.01
+                }
+            }
+        }
+    },
+    "profession_starships_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 2000,
+                    "intercept": 100000
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": {
+                            "slope": 200,
+                            "intercept": 10000
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_speeders": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 0.015,
+                    "intercept": 0.05
+                }
+            }
+        }
+    },
+    "profession_speeders_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 300,
+                    "intercept": 15000
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": {
+                            "slope": 30,
+                            "intercept": 1500
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_other_vehicles": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 0.01,
+                    "intercept": 0.03
+                }
+            }
+        }
+    },
+    "profession_other_vehicles_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 400,
+                    "intercept": 20000
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": {
+                            "slope": 40,
+                            "intercept": 2000
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_luxury_property": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 0.008,
+                    "intercept": 0.02
+                }
+            }
+        }
+    },
+    "profession_luxury_property_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 3000,
+                    "intercept": 150000
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": {
+                            "slope": 300,
+                            "intercept": 15000
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_galactic_stock": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 0.012,
+                    "intercept": 0.04
+                }
+            }
+        }
+    },
+    "profession_galactic_stock_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 800,
+                    "intercept": 40000
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": {
+                            "slope": 80,
+                            "intercept": 4000
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_business": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 0.01,
+                    "intercept": 0.03
+                }
+            }
+        }
+    },
+    "profession_business_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": {
+                    "slope": 2500,
+                    "intercept": 125000
+                }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": {
+                            "slope": 250,
+                            "intercept": 12500
+                        }
+                    }
+                }
+            }
+        }
+    },
     "metadata": {
         "currency": "credits",
         "era": "Clone Wars"
@@ -96,20 +369,17 @@ The configuration file has four main sections:
    - `mean_function`: Function configuration for the mean value
    - `noise_function`: Function configuration for the noise/variation
 
-2. **profession_has_primary_residence**: Optional dictionary mapping professions to their probability of owning a primary residence.
-   Each profession entry contains:
-   - `field_name`: The character attribute to use (e.g., "age")
-   - `mean_function`: Function configuration that outputs a probability between 0 and 1
-   The output probability determines whether a character owns a primary residence.
+2. **Asset Ownership and Value Fields**: For each asset type (primary residence, other properties, starships, speeders, other vehicles, luxury property, galactic stock, business), there are two configuration sections:
+   - `profession_has_*`: Defines the probability of owning that asset type
+     - `field_name`: The character attribute to use (e.g., "age")
+     - `mean_function`: Function configuration that outputs a probability between 0 and 1
+   - `profession_*_value` or `profession_*_net_value`: Defines the value distribution for owned assets
+     - `field_name`: The character attribute to use (e.g., "age")
+     - `mean_function`: Function configuration for the mean value
+     - `noise_function`: Function configuration for the value variation
+   The value distribution is only used if the character owns that asset type.
 
-3. **profession_primary_residence_value**: Optional dictionary mapping professions to their residence value distributions.
-   Each profession entry follows the same format as `profession_liquid_currency`, containing:
-   - `field_name`: The character attribute to use (e.g., "age")
-   - `mean_function`: Function configuration for the mean residence value
-   - `noise_function`: Function configuration for the value variation
-   This distribution is only used if the character owns a primary residence.
-
-4. **metadata**: Optional metadata fields
+3. **metadata**: Optional metadata fields
    - `currency`: The currency type (defaults to "credits")
    - `era`: The era this configuration is for
 
@@ -161,84 +431,12 @@ The configuration supports several function types for both mean and noise calcul
    }
    ```
 
-## Example: Complex Configuration
-
-```json
-{
-    "profession_liquid_currency": {
-        "merchant": {
-            "field_name": "experience",
-            "mean_function": {
-                "type": "exponential",
-                "params": {
-                    "base": 50,
-                    "rate": 0.1
-                }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "experience",
-                    "scale_factor": {
-                        "type": "quadratic",
-                        "params": {
-                            "a": 0.01,
-                            "b": 0,
-                            "c": 0
-                        }
-                    }
-                }
-            }
-        }
-    },
-    "profession_has_primary_residence": {
-        "merchant": {
-            "field_name": "experience",
-            "mean_function": {
-                "type": "exponential",
-                "params": {
-                    "base": 0.2,
-                    "rate": 0.05
-                }
-            }
-        }
-    },
-    "profession_primary_residence_value": {
-        "merchant": {
-            "field_name": "experience",
-            "mean_function": {
-                "type": "exponential",
-                "params": {
-                    "base": 100000,
-                    "rate": 0.05
-                }
-            },
-            "noise_function": {
-                "type": "lognormal",
-                "params": {
-                    "field_name": "experience",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": {
-                            "slope": 1000,
-                            "intercept": 10000
-                        }
-                    }
-                }
-            }
-        }
-    },
-    "metadata": {
-        "currency": "credits"
-    }
-}
-```
-
 ## Notes
 
 1. All monetary values are in the specified currency units (defaults to "credits")
 2. Functions can use any numeric character attribute (age, experience, etc.)
 3. Noise functions support normal, lognormal, and truncated normal distributions
 4. The configuration is validated when loaded to ensure all required fields are present
-5. Primary residence ownership is determined by a Bernoulli trial using the probability from `profession_has_primary_residence`
-6. Primary residence value is only generated if a character owns a primary residence 
+5. Asset ownership is determined by a Bernoulli trial using the probability from the corresponding `profession_has_*` field
+6. Asset values are only generated if a character owns that asset type
+7. Each asset type follows the same pattern: a probability of ownership and a value distribution if owned 

--- a/src/world_builder/net_worth_config.py
+++ b/src/world_builder/net_worth_config.py
@@ -7,6 +7,20 @@ The config is a JSON file that contains the following fields:
 - profession_liquid_currency: a dictionary mapping professions to their net worth distributions
 - profession_has_primary_residence: an optional dictionary mapping professions to their probability of owning a residence
 - profession_primary_residence_value: an optional dictionary mapping professions to their residence value distribution
+- profession_has_other_properties: an optional dictionary mapping professions to their probability of owning other properties
+- profession_other_properties_net_value: an optional dictionary mapping professions to their other properties value distribution
+- profession_has_starships: an optional dictionary mapping professions to their probability of owning starships
+- profession_starships_net_value: an optional dictionary mapping professions to their starships value distribution
+- profession_has_speeders: an optional dictionary mapping professions to their probability of owning speeders
+- profession_speeders_net_value: an optional dictionary mapping professions to their speeders value distribution
+- profession_has_other_vehicles: an optional dictionary mapping professions to their probability of owning other vehicles
+- profession_other_vehicles_net_value: an optional dictionary mapping professions to their other vehicles value distribution
+- profession_has_luxury_property: an optional dictionary mapping professions to their probability of owning luxury property
+- profession_luxury_property_net_value: an optional dictionary mapping professions to their luxury property value distribution
+- profession_has_galactic_stock: an optional dictionary mapping professions to their probability of owning galactic stock
+- profession_galactic_stock_net_value: an optional dictionary mapping professions to their galactic stock value distribution
+- profession_has_business: an optional dictionary mapping professions to their probability of owning a business
+- profession_business_net_value: an optional dictionary mapping professions to their business value distribution
 - metadata: optional metadata fields
 """
 
@@ -32,6 +46,20 @@ class NetWorthConfig(BaseModel):
         profession_liquid_currency: Maps each profession to its net worth distribution
         profession_has_primary_residence: Optional mapping of professions to their residence ownership probability
         profession_primary_residence_value: Optional mapping of professions to their residence value distribution
+        profession_has_other_properties: Optional mapping of professions to their other properties ownership probability
+        profession_other_properties_net_value: Optional mapping of professions to their other properties value distribution
+        profession_has_starships: Optional mapping of professions to their starships ownership probability
+        profession_starships_net_value: Optional mapping of professions to their starships value distribution
+        profession_has_speeders: Optional mapping of professions to their speeders ownership probability
+        profession_speeders_net_value: Optional mapping of professions to their speeders value distribution
+        profession_has_other_vehicles: Optional mapping of professions to their other vehicles ownership probability
+        profession_other_vehicles_net_value: Optional mapping of professions to their other vehicles value distribution
+        profession_has_luxury_property: Optional mapping of professions to their luxury property ownership probability
+        profession_luxury_property_net_value: Optional mapping of professions to their luxury property value distribution
+        profession_has_galactic_stock: Optional mapping of professions to their galactic stock ownership probability
+        profession_galactic_stock_net_value: Optional mapping of professions to their galactic stock value distribution
+        profession_has_business: Optional mapping of professions to their business ownership probability
+        profession_business_net_value: Optional mapping of professions to their business value distribution
         metadata: Optional metadata fields
     """
 
@@ -52,6 +80,94 @@ class NetWorthConfig(BaseModel):
     profession_primary_residence_value: Optional[Dict[str, FunctionBasedDist]] = Field(
         default=None,
         description="Optional mapping of professions to their residence value distribution.",
+    )
+
+    # Optional mapping of professions to their other properties ownership probability
+    profession_has_other_properties: Optional[Dict[str, BernoulliBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their other properties ownership probability.",
+    )
+
+    # Optional mapping of professions to their other properties value distribution
+    profession_other_properties_net_value: Optional[Dict[str, FunctionBasedDist]] = (
+        Field(
+            default=None,
+            description="Optional mapping of professions to their other properties value distribution.",
+        )
+    )
+
+    # Optional mapping of professions to their starships ownership probability
+    profession_has_starships: Optional[Dict[str, BernoulliBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their starships ownership probability.",
+    )
+
+    # Optional mapping of professions to their starships value distribution
+    profession_starships_net_value: Optional[Dict[str, FunctionBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their starships value distribution.",
+    )
+
+    # Optional mapping of professions to their speeders ownership probability
+    profession_has_speeders: Optional[Dict[str, BernoulliBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their speeders ownership probability.",
+    )
+
+    # Optional mapping of professions to their speeders value distribution
+    profession_speeders_net_value: Optional[Dict[str, FunctionBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their speeders value distribution.",
+    )
+
+    # Optional mapping of professions to their other vehicles ownership probability
+    profession_has_other_vehicles: Optional[Dict[str, BernoulliBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their other vehicles ownership probability.",
+    )
+
+    # Optional mapping of professions to their other vehicles value distribution
+    profession_other_vehicles_net_value: Optional[Dict[str, FunctionBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their other vehicles value distribution.",
+    )
+
+    # Optional mapping of professions to their luxury property ownership probability
+    profession_has_luxury_property: Optional[Dict[str, BernoulliBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their luxury property ownership probability.",
+    )
+
+    # Optional mapping of professions to their luxury property value distribution
+    profession_luxury_property_net_value: Optional[Dict[str, FunctionBasedDist]] = (
+        Field(
+            default=None,
+            description="Optional mapping of professions to their luxury property value distribution.",
+        )
+    )
+
+    # Optional mapping of professions to their galactic stock ownership probability
+    profession_has_galactic_stock: Optional[Dict[str, BernoulliBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their galactic stock ownership probability.",
+    )
+
+    # Optional mapping of professions to their galactic stock value distribution
+    profession_galactic_stock_net_value: Optional[Dict[str, FunctionBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their galactic stock value distribution.",
+    )
+
+    # Optional mapping of professions to their business ownership probability
+    profession_has_business: Optional[Dict[str, BernoulliBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their business ownership probability.",
+    )
+
+    # Optional mapping of professions to their business value distribution
+    profession_business_net_value: Optional[Dict[str, FunctionBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their business value distribution.",
     )
 
     # catch-all dict for any miscellaneous, constant metadata fields

--- a/src/world_builder/net_worth_config.py
+++ b/src/world_builder/net_worth_config.py
@@ -5,16 +5,22 @@ This helper function returns a Pydantic model, which automatically validates the
 
 The config is a JSON file that contains the following fields:
 - profession_liquid_currency: a dictionary mapping professions to their net worth distributions
+- profession_primary_residence: an optional dictionary mapping professions to their probability of owning a residence
 - metadata: optional metadata fields
 """
 
-from typing import Dict
+from typing import Dict, Optional
 import json
 from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from world_builder.distributions_config import Distribution, FunctionBasedDist
+from world_builder.distributions_config import (
+    Distribution,
+    FunctionBasedDist,
+    FunctionConfig,
+    BernoulliBasedDist,
+)
 
 
 class NetWorthConfig(BaseModel):
@@ -23,6 +29,7 @@ class NetWorthConfig(BaseModel):
 
     Attributes:
         profession_liquid_currency: Maps each profession to its net worth distribution
+        profession_primary_residence: Optional mapping of professions to their residence ownership probability
         metadata: Optional metadata fields
     """
 
@@ -31,6 +38,12 @@ class NetWorthConfig(BaseModel):
     # Maps each profession to its net worth distribution
     profession_liquid_currency: Dict[str, FunctionBasedDist] = Field(
         description="Required mapping of professions to their net worth distributions."
+    )
+
+    # Optional mapping of professions to their residence ownership probability
+    profession_primary_residence: Optional[Dict[str, BernoulliBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their residence ownership probability.",
     )
 
     # catch-all dict for any miscellaneous, constant metadata fields

--- a/src/world_builder/net_worth_config.py
+++ b/src/world_builder/net_worth_config.py
@@ -5,7 +5,8 @@ This helper function returns a Pydantic model, which automatically validates the
 
 The config is a JSON file that contains the following fields:
 - profession_liquid_currency: a dictionary mapping professions to their net worth distributions
-- profession_primary_residence: an optional dictionary mapping professions to their probability of owning a residence
+- profession_has_primary_residence: an optional dictionary mapping professions to their probability of owning a residence
+- profession_primary_residence_value: an optional dictionary mapping professions to their residence value distribution
 - metadata: optional metadata fields
 """
 
@@ -29,7 +30,8 @@ class NetWorthConfig(BaseModel):
 
     Attributes:
         profession_liquid_currency: Maps each profession to its net worth distribution
-        profession_primary_residence: Optional mapping of professions to their residence ownership probability
+        profession_has_primary_residence: Optional mapping of professions to their residence ownership probability
+        profession_primary_residence_value: Optional mapping of professions to their residence value distribution
         metadata: Optional metadata fields
     """
 
@@ -41,9 +43,15 @@ class NetWorthConfig(BaseModel):
     )
 
     # Optional mapping of professions to their residence ownership probability
-    profession_primary_residence: Optional[Dict[str, BernoulliBasedDist]] = Field(
+    profession_has_primary_residence: Optional[Dict[str, BernoulliBasedDist]] = Field(
         default=None,
         description="Optional mapping of professions to their residence ownership probability.",
+    )
+
+    # Optional mapping of professions to their residence value distribution
+    profession_primary_residence_value: Optional[Dict[str, FunctionBasedDist]] = Field(
+        default=None,
+        description="Optional mapping of professions to their residence value distribution.",
     )
 
     # catch-all dict for any miscellaneous, constant metadata fields

--- a/src/world_builder/net_worth_config.py
+++ b/src/world_builder/net_worth_config.py
@@ -4,23 +4,9 @@ This module implements a basic helper function, load_config, to load the net wor
 This helper function returns a Pydantic model, which automatically validates the config.
 
 The config is a JSON file that contains the following fields:
-- profession_liquid_currency: a dictionary mapping professions to their net worth distributions
-- profession_has_primary_residence: an optional dictionary mapping professions to their probability of owning a residence
-- profession_primary_residence_value: an optional dictionary mapping professions to their residence value distribution
-- profession_has_other_properties: an optional dictionary mapping professions to their probability of owning other properties
-- profession_other_properties_net_value: an optional dictionary mapping professions to their other properties value distribution
-- profession_has_starships: an optional dictionary mapping professions to their probability of owning starships
-- profession_starships_net_value: an optional dictionary mapping professions to their starships value distribution
-- profession_has_speeders: an optional dictionary mapping professions to their probability of owning speeders
-- profession_speeders_net_value: an optional dictionary mapping professions to their speeders value distribution
-- profession_has_other_vehicles: an optional dictionary mapping professions to their probability of owning other vehicles
-- profession_other_vehicles_net_value: an optional dictionary mapping professions to their other vehicles value distribution
-- profession_has_luxury_property: an optional dictionary mapping professions to their probability of owning luxury property
-- profession_luxury_property_net_value: an optional dictionary mapping professions to their luxury property value distribution
-- profession_has_galactic_stock: an optional dictionary mapping professions to their probability of owning galactic stock
-- profession_galactic_stock_net_value: an optional dictionary mapping professions to their galactic stock value distribution
-- profession_has_business: an optional dictionary mapping professions to their probability of owning a business
-- profession_business_net_value: an optional dictionary mapping professions to their business value distribution
+- profession_liquid_currency: a dictionary mapping professions to their net worth distributions (required)
+- profession_has: an optional dictionary mapping asset types to profession ownership probabilities
+- profession_value: an optional dictionary mapping asset types to profession value distributions
 - metadata: optional metadata fields
 """
 
@@ -43,131 +29,29 @@ class NetWorthConfig(BaseModel):
     Configuration for net worth generation.
 
     Attributes:
-        profession_liquid_currency: Maps each profession to its net worth distribution
-        profession_has_primary_residence: Optional mapping of professions to their residence ownership probability
-        profession_primary_residence_value: Optional mapping of professions to their residence value distribution
-        profession_has_other_properties: Optional mapping of professions to their other properties ownership probability
-        profession_other_properties_net_value: Optional mapping of professions to their other properties value distribution
-        profession_has_starships: Optional mapping of professions to their starships ownership probability
-        profession_starships_net_value: Optional mapping of professions to their starships value distribution
-        profession_has_speeders: Optional mapping of professions to their speeders ownership probability
-        profession_speeders_net_value: Optional mapping of professions to their speeders value distribution
-        profession_has_other_vehicles: Optional mapping of professions to their other vehicles ownership probability
-        profession_other_vehicles_net_value: Optional mapping of professions to their other vehicles value distribution
-        profession_has_luxury_property: Optional mapping of professions to their luxury property ownership probability
-        profession_luxury_property_net_value: Optional mapping of professions to their luxury property value distribution
-        profession_has_galactic_stock: Optional mapping of professions to their galactic stock ownership probability
-        profession_galactic_stock_net_value: Optional mapping of professions to their galactic stock value distribution
-        profession_has_business: Optional mapping of professions to their business ownership probability
-        profession_business_net_value: Optional mapping of professions to their business value distribution
+        profession_liquid_currency: Maps each profession to its net worth distribution (required)
+        profession_has: Optional mapping of asset types to profession ownership probabilities
+        profession_value: Optional mapping of asset types to profession value distributions
         metadata: Optional metadata fields
     """
 
     model_config = ConfigDict(frozen=True)
 
-    # Maps each profession to its net worth distribution
+    # Required mapping of professions to their net worth distributions
     profession_liquid_currency: Dict[str, FunctionBasedDist] = Field(
         description="Required mapping of professions to their net worth distributions."
     )
 
-    # Optional mapping of professions to their residence ownership probability
-    profession_has_primary_residence: Optional[Dict[str, BernoulliBasedDist]] = Field(
+    # Optional mapping of asset types to profession ownership probabilities
+    profession_has: Optional[Dict[str, Dict[str, BernoulliBasedDist]]] = Field(
         default=None,
-        description="Optional mapping of professions to their residence ownership probability.",
+        description="Optional mapping of asset types to profession ownership probabilities.",
     )
 
-    # Optional mapping of professions to their residence value distribution
-    profession_primary_residence_value: Optional[Dict[str, FunctionBasedDist]] = Field(
+    # Optional mapping of asset types to profession value distributions
+    profession_value: Optional[Dict[str, Dict[str, FunctionBasedDist]]] = Field(
         default=None,
-        description="Optional mapping of professions to their residence value distribution.",
-    )
-
-    # Optional mapping of professions to their other properties ownership probability
-    profession_has_other_properties: Optional[Dict[str, BernoulliBasedDist]] = Field(
-        default=None,
-        description="Optional mapping of professions to their other properties ownership probability.",
-    )
-
-    # Optional mapping of professions to their other properties value distribution
-    profession_other_properties_net_value: Optional[Dict[str, FunctionBasedDist]] = (
-        Field(
-            default=None,
-            description="Optional mapping of professions to their other properties value distribution.",
-        )
-    )
-
-    # Optional mapping of professions to their starships ownership probability
-    profession_has_starships: Optional[Dict[str, BernoulliBasedDist]] = Field(
-        default=None,
-        description="Optional mapping of professions to their starships ownership probability.",
-    )
-
-    # Optional mapping of professions to their starships value distribution
-    profession_starships_net_value: Optional[Dict[str, FunctionBasedDist]] = Field(
-        default=None,
-        description="Optional mapping of professions to their starships value distribution.",
-    )
-
-    # Optional mapping of professions to their speeders ownership probability
-    profession_has_speeders: Optional[Dict[str, BernoulliBasedDist]] = Field(
-        default=None,
-        description="Optional mapping of professions to their speeders ownership probability.",
-    )
-
-    # Optional mapping of professions to their speeders value distribution
-    profession_speeders_net_value: Optional[Dict[str, FunctionBasedDist]] = Field(
-        default=None,
-        description="Optional mapping of professions to their speeders value distribution.",
-    )
-
-    # Optional mapping of professions to their other vehicles ownership probability
-    profession_has_other_vehicles: Optional[Dict[str, BernoulliBasedDist]] = Field(
-        default=None,
-        description="Optional mapping of professions to their other vehicles ownership probability.",
-    )
-
-    # Optional mapping of professions to their other vehicles value distribution
-    profession_other_vehicles_net_value: Optional[Dict[str, FunctionBasedDist]] = Field(
-        default=None,
-        description="Optional mapping of professions to their other vehicles value distribution.",
-    )
-
-    # Optional mapping of professions to their luxury property ownership probability
-    profession_has_luxury_property: Optional[Dict[str, BernoulliBasedDist]] = Field(
-        default=None,
-        description="Optional mapping of professions to their luxury property ownership probability.",
-    )
-
-    # Optional mapping of professions to their luxury property value distribution
-    profession_luxury_property_net_value: Optional[Dict[str, FunctionBasedDist]] = (
-        Field(
-            default=None,
-            description="Optional mapping of professions to their luxury property value distribution.",
-        )
-    )
-
-    # Optional mapping of professions to their galactic stock ownership probability
-    profession_has_galactic_stock: Optional[Dict[str, BernoulliBasedDist]] = Field(
-        default=None,
-        description="Optional mapping of professions to their galactic stock ownership probability.",
-    )
-
-    # Optional mapping of professions to their galactic stock value distribution
-    profession_galactic_stock_net_value: Optional[Dict[str, FunctionBasedDist]] = Field(
-        default=None,
-        description="Optional mapping of professions to their galactic stock value distribution.",
-    )
-
-    # Optional mapping of professions to their business ownership probability
-    profession_has_business: Optional[Dict[str, BernoulliBasedDist]] = Field(
-        default=None,
-        description="Optional mapping of professions to their business ownership probability.",
-    )
-
-    # Optional mapping of professions to their business value distribution
-    profession_business_net_value: Optional[Dict[str, FunctionBasedDist]] = Field(
-        default=None,
-        description="Optional mapping of professions to their business value distribution.",
+        description="Optional mapping of asset types to profession value distributions.",
     )
 
     # catch-all dict for any miscellaneous, constant metadata fields

--- a/src/world_builder/net_worth_generator.py
+++ b/src/world_builder/net_worth_generator.py
@@ -26,6 +26,20 @@ class NetWorth:
         currency_type: The type of currency (e.g., "credits", "imperial_credits")
         owns_primary_residence: Whether the character owns their primary residence
         primary_residence_value: The value of the primary residence if owned, None otherwise
+        owns_other_properties: Whether the character owns other properties
+        other_properties_net_value: The value of other properties if owned, None otherwise
+        owns_starships: Whether the character owns starships
+        starships_net_value: The value of starships if owned, None otherwise
+        owns_speeders: Whether the character owns speeders
+        speeders_net_value: The value of speeders if owned, None otherwise
+        owns_other_vehicles: Whether the character owns other vehicles
+        other_vehicles_net_value: The value of other vehicles if owned, None otherwise
+        owns_luxury_property: Whether the character owns luxury property
+        luxury_property_net_value: The value of luxury property if owned, None otherwise
+        owns_galactic_stock: Whether the character owns galactic stock
+        galactic_stock_net_value: The value of galactic stock if owned, None otherwise
+        owns_business: Whether the character owns a business
+        business_net_value: The value of the business if owned, None otherwise
     """
 
     def __init__(
@@ -35,12 +49,40 @@ class NetWorth:
         currency_type: str,
         owns_primary_residence: Optional[bool] = None,
         primary_residence_value: Optional[float] = None,
+        owns_other_properties: Optional[bool] = None,
+        other_properties_net_value: Optional[float] = None,
+        owns_starships: Optional[bool] = None,
+        starships_net_value: Optional[float] = None,
+        owns_speeders: Optional[bool] = None,
+        speeders_net_value: Optional[float] = None,
+        owns_other_vehicles: Optional[bool] = None,
+        other_vehicles_net_value: Optional[float] = None,
+        owns_luxury_property: Optional[bool] = None,
+        luxury_property_net_value: Optional[float] = None,
+        owns_galactic_stock: Optional[bool] = None,
+        galactic_stock_net_value: Optional[float] = None,
+        owns_business: Optional[bool] = None,
+        business_net_value: Optional[float] = None,
     ):
         self._chain_code = chain_code
         self._liquid_currency = liquid_currency
         self._currency_type = currency_type
         self._owns_primary_residence = owns_primary_residence
         self._primary_residence_value = primary_residence_value
+        self._owns_other_properties = owns_other_properties
+        self._other_properties_net_value = other_properties_net_value
+        self._owns_starships = owns_starships
+        self._starships_net_value = starships_net_value
+        self._owns_speeders = owns_speeders
+        self._speeders_net_value = speeders_net_value
+        self._owns_other_vehicles = owns_other_vehicles
+        self._other_vehicles_net_value = other_vehicles_net_value
+        self._owns_luxury_property = owns_luxury_property
+        self._luxury_property_net_value = luxury_property_net_value
+        self._owns_galactic_stock = owns_galactic_stock
+        self._galactic_stock_net_value = galactic_stock_net_value
+        self._owns_business = owns_business
+        self._business_net_value = business_net_value
 
     @property
     def chain_code(self) -> str:
@@ -62,12 +104,100 @@ class NetWorth:
     def primary_residence_value(self) -> Optional[float]:
         return self._primary_residence_value
 
+    @property
+    def owns_other_properties(self) -> Optional[bool]:
+        return self._owns_other_properties
+
+    @property
+    def other_properties_net_value(self) -> Optional[float]:
+        return self._other_properties_net_value
+
+    @property
+    def owns_starships(self) -> Optional[bool]:
+        return self._owns_starships
+
+    @property
+    def starships_net_value(self) -> Optional[float]:
+        return self._starships_net_value
+
+    @property
+    def owns_speeders(self) -> Optional[bool]:
+        return self._owns_speeders
+
+    @property
+    def speeders_net_value(self) -> Optional[float]:
+        return self._speeders_net_value
+
+    @property
+    def owns_other_vehicles(self) -> Optional[bool]:
+        return self._owns_other_vehicles
+
+    @property
+    def other_vehicles_net_value(self) -> Optional[float]:
+        return self._other_vehicles_net_value
+
+    @property
+    def owns_luxury_property(self) -> Optional[bool]:
+        return self._owns_luxury_property
+
+    @property
+    def luxury_property_net_value(self) -> Optional[float]:
+        return self._luxury_property_net_value
+
+    @property
+    def owns_galactic_stock(self) -> Optional[bool]:
+        return self._owns_galactic_stock
+
+    @property
+    def galactic_stock_net_value(self) -> Optional[float]:
+        return self._galactic_stock_net_value
+
+    @property
+    def owns_business(self) -> Optional[bool]:
+        return self._owns_business
+
+    @property
+    def business_net_value(self) -> Optional[float]:
+        return self._business_net_value
+
     def __repr__(self) -> str:
         base_repr = f"NetWorth(chain_code={self.chain_code!r}, liquid_currency={self.liquid_currency}, currency_type={self.currency_type!r}"
         if self.owns_primary_residence is not None:
             base_repr += f", owns_primary_residence={self.owns_primary_residence!r}"
         if self.primary_residence_value is not None:
             base_repr += f", primary_residence_value={self.primary_residence_value!r}"
+        if self.owns_other_properties is not None:
+            base_repr += f", owns_other_properties={self.owns_other_properties!r}"
+        if self.other_properties_net_value is not None:
+            base_repr += (
+                f", other_properties_net_value={self.other_properties_net_value!r}"
+            )
+        if self.owns_starships is not None:
+            base_repr += f", owns_starships={self.owns_starships!r}"
+        if self.starships_net_value is not None:
+            base_repr += f", starships_net_value={self.starships_net_value!r}"
+        if self.owns_speeders is not None:
+            base_repr += f", owns_speeders={self.owns_speeders!r}"
+        if self.speeders_net_value is not None:
+            base_repr += f", speeders_net_value={self.speeders_net_value!r}"
+        if self.owns_other_vehicles is not None:
+            base_repr += f", owns_other_vehicles={self.owns_other_vehicles!r}"
+        if self.other_vehicles_net_value is not None:
+            base_repr += f", other_vehicles_net_value={self.other_vehicles_net_value!r}"
+        if self.owns_luxury_property is not None:
+            base_repr += f", owns_luxury_property={self.owns_luxury_property!r}"
+        if self.luxury_property_net_value is not None:
+            base_repr += (
+                f", luxury_property_net_value={self.luxury_property_net_value!r}"
+            )
+        if self.owns_galactic_stock is not None:
+            base_repr += f", owns_galactic_stock={self.owns_galactic_stock!r}"
+        if self.galactic_stock_net_value is not None:
+            base_repr += f", galactic_stock_net_value={self.galactic_stock_net_value!r}"
+        if self.owns_business is not None:
+            base_repr += f", owns_business={self.owns_business!r}"
+        if self.business_net_value is not None:
+            base_repr += f", business_net_value={self.business_net_value!r}"
         return base_repr + ")"
 
     def __eq__(self, other: object) -> bool:
@@ -79,6 +209,20 @@ class NetWorth:
             and self.currency_type == other.currency_type
             and self.owns_primary_residence == other.owns_primary_residence
             and self.primary_residence_value == other.primary_residence_value
+            and self.owns_other_properties == other.owns_other_properties
+            and self.other_properties_net_value == other.other_properties_net_value
+            and self.owns_starships == other.owns_starships
+            and self.starships_net_value == other.starships_net_value
+            and self.owns_speeders == other.owns_speeders
+            and self.speeders_net_value == other.speeders_net_value
+            and self.owns_other_vehicles == other.owns_other_vehicles
+            and self.other_vehicles_net_value == other.other_vehicles_net_value
+            and self.owns_luxury_property == other.owns_luxury_property
+            and self.luxury_property_net_value == other.luxury_property_net_value
+            and self.owns_galactic_stock == other.owns_galactic_stock
+            and self.galactic_stock_net_value == other.galactic_stock_net_value
+            and self.owns_business == other.owns_business
+            and self.business_net_value == other.business_net_value
         )
 
 
@@ -107,6 +251,49 @@ def evaluate_function(func_config: FunctionConfig, x: float) -> float:
         )
     else:
         raise ValueError(f"Unknown function type: {func_config.type}")
+
+
+def _generate_asset_value(
+    character: Character,
+    has_config: Optional[Dict[str, Any]],
+    value_config: Optional[Dict[str, Any]],
+    profession: str,
+) -> tuple[Optional[bool], Optional[float]]:
+    """
+    Helper function to generate ownership and value for an asset type.
+
+    Args:
+        character: The character to generate for
+        has_config: The configuration for asset ownership probability
+        value_config: The configuration for asset value distribution
+        profession: The character's profession
+
+    Returns:
+        A tuple of (owns_asset, asset_value) where both could be None
+    """
+    owns_asset = None
+    asset_value = None
+
+    if has_config is not None and profession in has_config:
+        residence_config = has_config[profession]
+        field_value = getattr(character, residence_config.field_name)
+        probability = evaluate_function(residence_config.mean_function, field_value)
+        # Ensure probability is between 0 and 1
+        probability = max(0.0, min(1.0, probability))
+        owns_asset = random.random() < probability
+
+        # If they own the asset, generate its value
+        if owns_asset and value_config is not None:
+            if profession in value_config:
+                value_config_data = value_config[profession]
+                field_value = getattr(character, value_config_data.field_name)
+                config_dict = value_config_data.model_dump()
+                config_dict["type"] = "function_based"
+                asset_value = sample_from_config(config_dict, field_value)
+                # Ensure the value is positive
+                asset_value = max(0, asset_value)
+
+    return owns_asset, asset_value
 
 
 def generate_net_worth(character: Character, config: NetWorthConfig) -> NetWorth:
@@ -145,35 +332,62 @@ def generate_net_worth(character: Character, config: NetWorthConfig) -> NetWorth
     # Get currency type from metadata, defaulting to "credits" if not specified
     currency_type = config.metadata.get("currency", "credits")
 
-    # Generate primary residence ownership if configured
-    owns_primary_residence = None
-    primary_residence_value = None
-    if (
-        config.profession_has_primary_residence is not None
-        and character.profession in config.profession_has_primary_residence
-    ):
-        residence_config = config.profession_has_primary_residence[character.profession]
-        field_value = getattr(character, residence_config.field_name)
-        probability = evaluate_function(residence_config.mean_function, field_value)
-        # Ensure probability is between 0 and 1
-        probability = max(0.0, min(1.0, probability))
-        owns_primary_residence = random.random() < probability
+    # Generate all asset ownership and values
+    owns_primary_residence, primary_residence_value = _generate_asset_value(
+        character,
+        config.profession_has_primary_residence,
+        config.profession_primary_residence_value,
+        character.profession,
+    )
 
-        # If they own a residence, generate its value
-        if (
-            owns_primary_residence
-            and config.profession_primary_residence_value is not None
-        ):
-            if character.profession in config.profession_primary_residence_value:
-                value_config = config.profession_primary_residence_value[
-                    character.profession
-                ]
-                field_value = getattr(character, value_config.field_name)
-                config_dict = value_config.model_dump()
-                config_dict["type"] = "function_based"
-                primary_residence_value = sample_from_config(config_dict, field_value)
-                # Ensure the value is positive
-                primary_residence_value = max(0, primary_residence_value)
+    owns_other_properties, other_properties_net_value = _generate_asset_value(
+        character,
+        config.profession_has_other_properties,
+        config.profession_other_properties_net_value,
+        character.profession,
+    )
+
+    owns_starships, starships_net_value = _generate_asset_value(
+        character,
+        config.profession_has_starships,
+        config.profession_starships_net_value,
+        character.profession,
+    )
+
+    owns_speeders, speeders_net_value = _generate_asset_value(
+        character,
+        config.profession_has_speeders,
+        config.profession_speeders_net_value,
+        character.profession,
+    )
+
+    owns_other_vehicles, other_vehicles_net_value = _generate_asset_value(
+        character,
+        config.profession_has_other_vehicles,
+        config.profession_other_vehicles_net_value,
+        character.profession,
+    )
+
+    owns_luxury_property, luxury_property_net_value = _generate_asset_value(
+        character,
+        config.profession_has_luxury_property,
+        config.profession_luxury_property_net_value,
+        character.profession,
+    )
+
+    owns_galactic_stock, galactic_stock_net_value = _generate_asset_value(
+        character,
+        config.profession_has_galactic_stock,
+        config.profession_galactic_stock_net_value,
+        character.profession,
+    )
+
+    owns_business, business_net_value = _generate_asset_value(
+        character,
+        config.profession_has_business,
+        config.profession_business_net_value,
+        character.profession,
+    )
 
     return NetWorth(
         chain_code=character.chain_code,
@@ -181,4 +395,18 @@ def generate_net_worth(character: Character, config: NetWorthConfig) -> NetWorth
         currency_type=currency_type,
         owns_primary_residence=owns_primary_residence,
         primary_residence_value=primary_residence_value,
+        owns_other_properties=owns_other_properties,
+        other_properties_net_value=other_properties_net_value,
+        owns_starships=owns_starships,
+        starships_net_value=starships_net_value,
+        owns_speeders=owns_speeders,
+        speeders_net_value=speeders_net_value,
+        owns_other_vehicles=owns_other_vehicles,
+        other_vehicles_net_value=other_vehicles_net_value,
+        owns_luxury_property=owns_luxury_property,
+        luxury_property_net_value=luxury_property_net_value,
+        owns_galactic_stock=owns_galactic_stock,
+        galactic_stock_net_value=galactic_stock_net_value,
+        owns_business=owns_business,
+        business_net_value=business_net_value,
     )

--- a/src/world_builder/net_worth_generator.py
+++ b/src/world_builder/net_worth_generator.py
@@ -20,26 +20,16 @@ class NetWorth:
     """
     Represents a character's net worth.
 
-    Attributes:
-        chain_code: The unique identifier for this net worth record
-        liquid_currency: The amount of liquid currency the character has
-        currency_type: The type of currency (e.g., "credits", "imperial_credits")
-        owns_primary_residence: Whether the character owns their primary residence
-        primary_residence_value: The value of the primary residence if owned, None otherwise
-        owns_other_properties: Whether the character owns other properties
-        other_properties_net_value: The value of other properties if owned, None otherwise
-        owns_starships: Whether the character owns starships
-        starships_net_value: The value of starships if owned, None otherwise
-        owns_speeders: Whether the character owns speeders
-        speeders_net_value: The value of speeders if owned, None otherwise
-        owns_other_vehicles: Whether the character owns other vehicles
-        other_vehicles_net_value: The value of other vehicles if owned, None otherwise
-        owns_luxury_property: Whether the character owns luxury property
-        luxury_property_net_value: The value of luxury property if owned, None otherwise
-        owns_galactic_stock: Whether the character owns galactic stock
-        galactic_stock_net_value: The value of galactic stock if owned, None otherwise
-        owns_business: Whether the character owns a business
-        business_net_value: The value of the business if owned, None otherwise
+    This class uses dynamic attribute assignment to store net worth information.
+    Required attributes:
+        - chain_code: The unique identifier for this net worth record
+        - liquid_currency: The amount of liquid currency the character has
+        - currency_type: The type of currency (e.g., "credits", "imperial_credits")
+
+    Optional attributes are dynamically generated based on asset types:
+        For each asset type (e.g. "primary_residence", "starships", etc.):
+        - owns_{asset_type}: Whether the character owns this type of asset
+        - {asset_type}_value: The value of the asset if owned (or {asset_type}_net_value for some types)
     """
 
     def __init__(
@@ -47,182 +37,100 @@ class NetWorth:
         chain_code: str,
         liquid_currency: float,
         currency_type: str,
-        owns_primary_residence: Optional[bool] = None,
-        primary_residence_value: Optional[float] = None,
-        owns_other_properties: Optional[bool] = None,
-        other_properties_net_value: Optional[float] = None,
-        owns_starships: Optional[bool] = None,
-        starships_net_value: Optional[float] = None,
-        owns_speeders: Optional[bool] = None,
-        speeders_net_value: Optional[float] = None,
-        owns_other_vehicles: Optional[bool] = None,
-        other_vehicles_net_value: Optional[float] = None,
-        owns_luxury_property: Optional[bool] = None,
-        luxury_property_net_value: Optional[float] = None,
-        owns_galactic_stock: Optional[bool] = None,
-        galactic_stock_net_value: Optional[float] = None,
-        owns_business: Optional[bool] = None,
-        business_net_value: Optional[float] = None,
+        **attributes: Any,
     ):
-        self._chain_code = chain_code
-        self._liquid_currency = liquid_currency
-        self._currency_type = currency_type
-        self._owns_primary_residence = owns_primary_residence
-        self._primary_residence_value = primary_residence_value
-        self._owns_other_properties = owns_other_properties
-        self._other_properties_net_value = other_properties_net_value
-        self._owns_starships = owns_starships
-        self._starships_net_value = starships_net_value
-        self._owns_speeders = owns_speeders
-        self._speeders_net_value = speeders_net_value
-        self._owns_other_vehicles = owns_other_vehicles
-        self._other_vehicles_net_value = other_vehicles_net_value
-        self._owns_luxury_property = owns_luxury_property
-        self._luxury_property_net_value = luxury_property_net_value
-        self._owns_galactic_stock = owns_galactic_stock
-        self._galactic_stock_net_value = galactic_stock_net_value
-        self._owns_business = owns_business
-        self._business_net_value = business_net_value
+        """
+        Initialize a NetWorth instance with required and optional attributes.
 
-    @property
-    def chain_code(self) -> str:
-        return self._chain_code
+        Args:
+            chain_code: The unique identifier for this net worth record
+            liquid_currency: The amount of liquid currency
+            currency_type: The type of currency
+            **attributes: Additional attributes to set (e.g. owns_primary_residence, primary_residence_value)
+        """
+        # Initialize flags and tracking
+        super().__setattr__("_initializing", True)
+        super().__setattr__("_attribute_names", set())
 
-    @property
-    def liquid_currency(self) -> float:
-        return self._liquid_currency
+        # Set required attributes
+        self._set_initial_attr("chain_code", chain_code)
+        self._set_initial_attr("liquid_currency", liquid_currency)
+        self._set_initial_attr("currency_type", currency_type)
 
-    @property
-    def currency_type(self) -> str:
-        return self._currency_type
+        # Set optional attributes dynamically
+        for name, value in attributes.items():
+            if not name.startswith("_"):  # Only set non-private attributes
+                self._set_initial_attr(name, value)
 
-    @property
-    def owns_primary_residence(self) -> Optional[bool]:
-        return self._owns_primary_residence
+        # Mark initialization as complete
+        super().__setattr__("_initializing", False)
 
-    @property
-    def primary_residence_value(self) -> Optional[float]:
-        return self._primary_residence_value
+    def _set_initial_attr(self, name: str, value: Any) -> None:
+        """Helper method for setting initial attributes during initialization."""
+        private_name = f"_{name}"
+        super().__setattr__(private_name, value)
+        self._attribute_names.add(name)
+        self._attribute_names.add(private_name)
 
-    @property
-    def owns_other_properties(self) -> Optional[bool]:
-        return self._owns_other_properties
+    def __getattr__(self, name: str) -> Any:
+        """
+        Provides access to attributes via properties.
+        This is called when an attribute is not found through normal lookup.
+        """
+        if name.startswith("_"):
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            )
 
-    @property
-    def other_properties_net_value(self) -> Optional[float]:
-        return self._other_properties_net_value
+        private_name = f"_{name}"
+        if hasattr(self, private_name):
+            return getattr(self, private_name)
 
-    @property
-    def owns_starships(self) -> Optional[bool]:
-        return self._owns_starships
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{name}'"
+        )
 
-    @property
-    def starships_net_value(self) -> Optional[float]:
-        return self._starships_net_value
+    def __setattr__(self, name: str, value: Any) -> None:
+        """
+        Prevents modification of attributes after initialization.
+        """
+        # Allow setting internal flags during initialization
+        if name in ("_attribute_names", "_initializing"):
+            super().__setattr__(name, value)
+            return
 
-    @property
-    def owns_speeders(self) -> Optional[bool]:
-        return self._owns_speeders
+        # If we're still initializing, allow setting through the proper method
+        if hasattr(self, "_initializing") and self._initializing:
+            # This should only happen through _set_initial_attr, but just in case
+            super().__setattr__(name, value)
+            return
 
-    @property
-    def speeders_net_value(self) -> Optional[float]:
-        return self._speeders_net_value
-
-    @property
-    def owns_other_vehicles(self) -> Optional[bool]:
-        return self._owns_other_vehicles
-
-    @property
-    def other_vehicles_net_value(self) -> Optional[float]:
-        return self._other_vehicles_net_value
-
-    @property
-    def owns_luxury_property(self) -> Optional[bool]:
-        return self._owns_luxury_property
-
-    @property
-    def luxury_property_net_value(self) -> Optional[float]:
-        return self._luxury_property_net_value
-
-    @property
-    def owns_galactic_stock(self) -> Optional[bool]:
-        return self._owns_galactic_stock
-
-    @property
-    def galactic_stock_net_value(self) -> Optional[float]:
-        return self._galactic_stock_net_value
-
-    @property
-    def owns_business(self) -> Optional[bool]:
-        return self._owns_business
-
-    @property
-    def business_net_value(self) -> Optional[float]:
-        return self._business_net_value
+        # After initialization, prevent all attribute modifications
+        raise AttributeError(
+            f"Can't set attribute '{name}' - NetWorth objects are immutable after initialization"
+        )
 
     def __repr__(self) -> str:
-        base_repr = f"NetWorth(chain_code={self.chain_code!r}, liquid_currency={self.liquid_currency}, currency_type={self.currency_type!r}"
-        if self.owns_primary_residence is not None:
-            base_repr += f", owns_primary_residence={self.owns_primary_residence!r}"
-        if self.primary_residence_value is not None:
-            base_repr += f", primary_residence_value={self.primary_residence_value!r}"
-        if self.owns_other_properties is not None:
-            base_repr += f", owns_other_properties={self.owns_other_properties!r}"
-        if self.other_properties_net_value is not None:
-            base_repr += (
-                f", other_properties_net_value={self.other_properties_net_value!r}"
-            )
-        if self.owns_starships is not None:
-            base_repr += f", owns_starships={self.owns_starships!r}"
-        if self.starships_net_value is not None:
-            base_repr += f", starships_net_value={self.starships_net_value!r}"
-        if self.owns_speeders is not None:
-            base_repr += f", owns_speeders={self.owns_speeders!r}"
-        if self.speeders_net_value is not None:
-            base_repr += f", speeders_net_value={self.speeders_net_value!r}"
-        if self.owns_other_vehicles is not None:
-            base_repr += f", owns_other_vehicles={self.owns_other_vehicles!r}"
-        if self.other_vehicles_net_value is not None:
-            base_repr += f", other_vehicles_net_value={self.other_vehicles_net_value!r}"
-        if self.owns_luxury_property is not None:
-            base_repr += f", owns_luxury_property={self.owns_luxury_property!r}"
-        if self.luxury_property_net_value is not None:
-            base_repr += (
-                f", luxury_property_net_value={self.luxury_property_net_value!r}"
-            )
-        if self.owns_galactic_stock is not None:
-            base_repr += f", owns_galactic_stock={self.owns_galactic_stock!r}"
-        if self.galactic_stock_net_value is not None:
-            base_repr += f", galactic_stock_net_value={self.galactic_stock_net_value!r}"
-        if self.owns_business is not None:
-            base_repr += f", owns_business={self.owns_business!r}"
-        if self.business_net_value is not None:
-            base_repr += f", business_net_value={self.business_net_value!r}"
-        return base_repr + ")"
+        """
+        Returns a string representation of the NetWorth instance.
+        """
+        attrs = []
+        for name in sorted(self._attribute_names):
+            if not name.startswith("_"):  # Only include public names in repr
+                value = getattr(self, name)
+                attrs.append(f"{name}={value!r}")
+        return f"NetWorth({', '.join(attrs)})"
 
     def __eq__(self, other: object) -> bool:
+        """
+        Compares two NetWorth instances for equality.
+        """
         if not isinstance(other, NetWorth):
             return NotImplemented
-        return (
-            self.chain_code == other.chain_code
-            and self.liquid_currency == other.liquid_currency
-            and self.currency_type == other.currency_type
-            and self.owns_primary_residence == other.owns_primary_residence
-            and self.primary_residence_value == other.primary_residence_value
-            and self.owns_other_properties == other.owns_other_properties
-            and self.other_properties_net_value == other.other_properties_net_value
-            and self.owns_starships == other.owns_starships
-            and self.starships_net_value == other.starships_net_value
-            and self.owns_speeders == other.owns_speeders
-            and self.speeders_net_value == other.speeders_net_value
-            and self.owns_other_vehicles == other.owns_other_vehicles
-            and self.other_vehicles_net_value == other.other_vehicles_net_value
-            and self.owns_luxury_property == other.owns_luxury_property
-            and self.luxury_property_net_value == other.luxury_property_net_value
-            and self.owns_galactic_stock == other.owns_galactic_stock
-            and self.galactic_stock_net_value == other.galactic_stock_net_value
-            and self.owns_business == other.owns_business
-            and self.business_net_value == other.business_net_value
+        return all(
+            getattr(self, name) == getattr(other, name)
+            for name in self._attribute_names
+            if not name.startswith("_")
         )
 
 

--- a/src/world_builder/net_worth_generator.py
+++ b/src/world_builder/net_worth_generator.py
@@ -258,6 +258,7 @@ def _generate_asset_value(
     has_config: Optional[Dict[str, Any]],
     value_config: Optional[Dict[str, Any]],
     profession: str,
+    asset_type: str,
 ) -> tuple[Optional[bool], Optional[float]]:
     """
     Helper function to generate ownership and value for an asset type.
@@ -267,6 +268,7 @@ def _generate_asset_value(
         has_config: The configuration for asset ownership probability
         value_config: The configuration for asset value distribution
         profession: The character's profession
+        asset_type: The type of asset to generate for
 
     Returns:
         A tuple of (owns_asset, asset_value) where both could be None
@@ -274,8 +276,12 @@ def _generate_asset_value(
     owns_asset = None
     asset_value = None
 
-    if has_config is not None and profession in has_config:
-        residence_config = has_config[profession]
+    if (
+        has_config is not None
+        and asset_type in has_config
+        and profession in has_config[asset_type]
+    ):
+        residence_config = has_config[asset_type][profession]
         field_value = getattr(character, residence_config.field_name)
         probability = evaluate_function(residence_config.mean_function, field_value)
         # Ensure probability is between 0 and 1
@@ -284,8 +290,8 @@ def _generate_asset_value(
 
         # If they own the asset, generate its value
         if owns_asset and value_config is not None:
-            if profession in value_config:
-                value_config_data = value_config[profession]
+            if asset_type in value_config and profession in value_config[asset_type]:
+                value_config_data = value_config[asset_type][profession]
                 field_value = getattr(character, value_config_data.field_name)
                 config_dict = value_config_data.model_dump()
                 config_dict["type"] = "function_based"
@@ -335,58 +341,66 @@ def generate_net_worth(character: Character, config: NetWorthConfig) -> NetWorth
     # Generate all asset ownership and values
     owns_primary_residence, primary_residence_value = _generate_asset_value(
         character,
-        config.profession_has_primary_residence,
-        config.profession_primary_residence_value,
+        config.profession_has,
+        config.profession_value,
         character.profession,
+        "primary_residence",
     )
 
     owns_other_properties, other_properties_net_value = _generate_asset_value(
         character,
-        config.profession_has_other_properties,
-        config.profession_other_properties_net_value,
+        config.profession_has,
+        config.profession_value,
         character.profession,
+        "other_properties",
     )
 
     owns_starships, starships_net_value = _generate_asset_value(
         character,
-        config.profession_has_starships,
-        config.profession_starships_net_value,
+        config.profession_has,
+        config.profession_value,
         character.profession,
+        "starships",
     )
 
     owns_speeders, speeders_net_value = _generate_asset_value(
         character,
-        config.profession_has_speeders,
-        config.profession_speeders_net_value,
+        config.profession_has,
+        config.profession_value,
         character.profession,
+        "speeders",
     )
 
     owns_other_vehicles, other_vehicles_net_value = _generate_asset_value(
         character,
-        config.profession_has_other_vehicles,
-        config.profession_other_vehicles_net_value,
+        config.profession_has,
+        config.profession_value,
         character.profession,
+        "other_vehicles",
     )
 
     owns_luxury_property, luxury_property_net_value = _generate_asset_value(
         character,
-        config.profession_has_luxury_property,
-        config.profession_luxury_property_net_value,
+        config.profession_has,
+        config.profession_value,
         character.profession,
+        "luxury_property",
     )
 
     owns_galactic_stock, galactic_stock_net_value = _generate_asset_value(
         character,
-        config.profession_has_galactic_stock,
-        config.profession_galactic_stock_net_value,
+        config.profession_has,
+        config.profession_value,
         character.profession,
+        "galactic_stock",
     )
 
     owns_business, business_net_value = _generate_asset_value(
         character,
-        config.profession_has_business,
-        config.profession_business_net_value,
+        config.profession_has,
+        config.profession_value,
         character.profession,
+        "business",
     )
 
     return NetWorth(

--- a/test/world_builder/config/nw_config_small.json
+++ b/test/world_builder/config/nw_config_small.json
@@ -18,12 +18,31 @@
             }
         }
     },
-    "profession_primary_residence": {
+    "profession_has_primary_residence": {
         "farmer": {
             "field_name": "age",
             "mean_function": {
                 "type": "linear",
                 "params": { "slope": 0.02, "intercept": 0.1 }
+            }
+        }
+    },
+    "profession_primary_residence_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 1000, "intercept": 50000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 100, "intercept": 5000 }
+                    }
+                }
             }
         }
     },

--- a/test/world_builder/config/nw_config_small.json
+++ b/test/world_builder/config/nw_config_small.json
@@ -18,225 +18,229 @@
             }
         }
     },
-    "profession_has_primary_residence": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.02, "intercept": 0.1 }
+    "profession_has": {
+        "primary_residence": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.02, "intercept": 0.1 }
+                }
             }
-        }
-    },
-    "profession_primary_residence_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 1000, "intercept": 50000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 100, "intercept": 5000 }
-                    }
+        },
+        "other_properties": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.01, "intercept": 0.05 }
+                }
+            }
+        },
+        "starships": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.005, "intercept": 0.01 }
+                }
+            }
+        },
+        "speeders": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.015, "intercept": 0.05 }
+                }
+            }
+        },
+        "other_vehicles": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.01, "intercept": 0.03 }
+                }
+            }
+        },
+        "luxury_property": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.008, "intercept": 0.02 }
+                }
+            }
+        },
+        "galactic_stock": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.012, "intercept": 0.04 }
+                }
+            }
+        },
+        "business": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 0.01, "intercept": 0.03 }
                 }
             }
         }
     },
-    "profession_has_other_properties": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.01, "intercept": 0.05 }
-            }
-        }
-    },
-    "profession_other_properties_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 500, "intercept": 25000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 50, "intercept": 2500 }
+    "profession_value": {
+        "primary_residence": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 1000, "intercept": 50000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 100, "intercept": 5000 }
+                        }
                     }
                 }
             }
-        }
-    },
-    "profession_has_starships": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.005, "intercept": 0.01 }
-            }
-        }
-    },
-    "profession_starships_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 2000, "intercept": 100000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 200, "intercept": 10000 }
+        },
+        "other_properties": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 500, "intercept": 25000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 50, "intercept": 2500 }
+                        }
                     }
                 }
             }
-        }
-    },
-    "profession_has_speeders": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.015, "intercept": 0.05 }
-            }
-        }
-    },
-    "profession_speeders_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 300, "intercept": 15000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 30, "intercept": 1500 }
+        },
+        "starships": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 2000, "intercept": 100000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 200, "intercept": 10000 }
+                        }
                     }
                 }
             }
-        }
-    },
-    "profession_has_other_vehicles": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.01, "intercept": 0.03 }
-            }
-        }
-    },
-    "profession_other_vehicles_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 400, "intercept": 20000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 40, "intercept": 2000 }
+        },
+        "speeders": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 300, "intercept": 15000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 30, "intercept": 1500 }
+                        }
                     }
                 }
             }
-        }
-    },
-    "profession_has_luxury_property": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.008, "intercept": 0.02 }
-            }
-        }
-    },
-    "profession_luxury_property_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 3000, "intercept": 150000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 300, "intercept": 15000 }
+        },
+        "other_vehicles": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 400, "intercept": 20000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 40, "intercept": 2000 }
+                        }
                     }
                 }
             }
-        }
-    },
-    "profession_has_galactic_stock": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.012, "intercept": 0.04 }
-            }
-        }
-    },
-    "profession_galactic_stock_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 800, "intercept": 40000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 80, "intercept": 4000 }
+        },
+        "luxury_property": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 3000, "intercept": 150000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 300, "intercept": 15000 }
+                        }
                     }
                 }
             }
-        }
-    },
-    "profession_has_business": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 0.01, "intercept": 0.03 }
+        },
+        "galactic_stock": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 800, "intercept": 40000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 80, "intercept": 4000 }
+                        }
+                    }
+                }
             }
-        }
-    },
-    "profession_business_net_value": {
-        "farmer": {
-            "field_name": "age",
-            "mean_function": {
-                "type": "linear",
-                "params": { "slope": 2500, "intercept": 125000 }
-            },
-            "noise_function": {
-                "type": "normal",
-                "params": {
-                    "field_name": "age",
-                    "scale_factor": {
-                        "type": "linear",
-                        "params": { "slope": 250, "intercept": 12500 }
+        },
+        "business": {
+            "farmer": {
+                "field_name": "age",
+                "mean_function": {
+                    "type": "linear",
+                    "params": { "slope": 2500, "intercept": 125000 }
+                },
+                "noise_function": {
+                    "type": "normal",
+                    "params": {
+                        "field_name": "age",
+                        "scale_factor": {
+                            "type": "linear",
+                            "params": { "slope": 250, "intercept": 12500 }
+                        }
                     }
                 }
             }

--- a/test/world_builder/config/nw_config_small.json
+++ b/test/world_builder/config/nw_config_small.json
@@ -1,0 +1,34 @@
+{
+    "profession_liquid_currency": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 5, "intercept": 100 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 0.1, "intercept": 0 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_primary_residence": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.02, "intercept": 0.1 }
+            }
+        }
+    },
+    "metadata": {
+        "currency": "credits",
+        "era": "Clone Wars"
+    }
+} 

--- a/test/world_builder/config/nw_config_small.json
+++ b/test/world_builder/config/nw_config_small.json
@@ -46,6 +46,202 @@
             }
         }
     },
+    "profession_has_other_properties": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.01, "intercept": 0.05 }
+            }
+        }
+    },
+    "profession_other_properties_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 500, "intercept": 25000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 50, "intercept": 2500 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_starships": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.005, "intercept": 0.01 }
+            }
+        }
+    },
+    "profession_starships_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 2000, "intercept": 100000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 200, "intercept": 10000 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_speeders": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.015, "intercept": 0.05 }
+            }
+        }
+    },
+    "profession_speeders_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 300, "intercept": 15000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 30, "intercept": 1500 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_other_vehicles": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.01, "intercept": 0.03 }
+            }
+        }
+    },
+    "profession_other_vehicles_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 400, "intercept": 20000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 40, "intercept": 2000 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_luxury_property": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.008, "intercept": 0.02 }
+            }
+        }
+    },
+    "profession_luxury_property_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 3000, "intercept": 150000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 300, "intercept": 15000 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_galactic_stock": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.012, "intercept": 0.04 }
+            }
+        }
+    },
+    "profession_galactic_stock_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 800, "intercept": 40000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 80, "intercept": 4000 }
+                    }
+                }
+            }
+        }
+    },
+    "profession_has_business": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 0.01, "intercept": 0.03 }
+            }
+        }
+    },
+    "profession_business_net_value": {
+        "farmer": {
+            "field_name": "age",
+            "mean_function": {
+                "type": "linear",
+                "params": { "slope": 2500, "intercept": 125000 }
+            },
+            "noise_function": {
+                "type": "normal",
+                "params": {
+                    "field_name": "age",
+                    "scale_factor": {
+                        "type": "linear",
+                        "params": { "slope": 250, "intercept": 12500 }
+                    }
+                }
+            }
+        }
+    },
     "metadata": {
         "currency": "credits",
         "era": "Clone Wars"

--- a/test/world_builder/test_net_worth_config.py
+++ b/test/world_builder/test_net_worth_config.py
@@ -1,3 +1,7 @@
+"""
+Tests for the net worth configuration module.
+"""
+
 from pathlib import Path
 
 import pytest
@@ -293,20 +297,22 @@ def test_load_config_with_primary_residence():
 
     # Test basic structure
     assert isinstance(config, NetWorthConfig)
-    assert config.profession_has_primary_residence is not None
-    assert config.profession_primary_residence_value is not None
-    assert "farmer" in config.profession_has_primary_residence
-    assert "farmer" in config.profession_primary_residence_value
+    assert config.profession_has is not None
+    assert config.profession_value is not None
+    assert "primary_residence" in config.profession_has
+    assert "primary_residence" in config.profession_value
+    assert "farmer" in config.profession_has["primary_residence"]
+    assert "farmer" in config.profession_value["primary_residence"]
 
     # Test residence ownership config structure
-    residence_config = config.profession_has_primary_residence["farmer"]
+    residence_config = config.profession_has["primary_residence"]["farmer"]
     assert residence_config.field_name == "age"
     assert residence_config.mean_function.type == "linear"
     assert residence_config.mean_function.params.slope == 0.02
     assert residence_config.mean_function.params.intercept == 0.1
 
     # Test residence value config structure
-    value_config = config.profession_primary_residence_value["farmer"]
+    value_config = config.profession_value["primary_residence"]["farmer"]
     assert value_config.field_name == "age"
     assert value_config.mean_function.type == "linear"
     assert value_config.mean_function.params.slope == 1000
@@ -326,28 +332,31 @@ def test_load_config_with_all_assets():
 
     # Test basic structure
     assert isinstance(config, NetWorthConfig)
-    assert config.profession_has_primary_residence is not None
-    assert config.profession_primary_residence_value is not None
-    assert config.profession_has_other_properties is not None
-    assert config.profession_other_properties_net_value is not None
-    assert config.profession_has_starships is not None
-    assert config.profession_starships_net_value is not None
-    assert config.profession_has_speeders is not None
-    assert config.profession_speeders_net_value is not None
-    assert config.profession_has_other_vehicles is not None
-    assert config.profession_other_vehicles_net_value is not None
-    assert config.profession_has_luxury_property is not None
-    assert config.profession_luxury_property_net_value is not None
-    assert config.profession_has_galactic_stock is not None
-    assert config.profession_galactic_stock_net_value is not None
-    assert config.profession_has_business is not None
-    assert config.profession_business_net_value is not None
+    assert config.profession_has is not None
+    assert config.profession_value is not None
+
+    # Test that each asset type exists in both has and value configs
+    asset_types = [
+        "primary_residence",
+        "other_properties",
+        "starships",
+        "speeders",
+        "other_vehicles",
+        "luxury_property",
+        "galactic_stock",
+        "business",
+    ]
+
+    for asset_type in asset_types:
+        assert asset_type in config.profession_has
+        assert asset_type in config.profession_value
+        assert "farmer" in config.profession_has[asset_type]
+        assert "farmer" in config.profession_value[asset_type]
 
     # Test that each asset type has the correct structure for "farmer" profession
     asset_configs = [
         (
-            "profession_has_primary_residence",
-            "profession_primary_residence_value",
+            "primary_residence",
             0.02,
             0.1,
             1000,
@@ -356,8 +365,7 @@ def test_load_config_with_all_assets():
             5000,
         ),  # ownership_slope, ownership_intercept, value_slope, value_intercept, noise_slope, noise_intercept
         (
-            "profession_has_other_properties",
-            "profession_other_properties_net_value",
+            "other_properties",
             0.01,
             0.05,
             500,
@@ -366,8 +374,7 @@ def test_load_config_with_all_assets():
             2500,
         ),
         (
-            "profession_has_starships",
-            "profession_starships_net_value",
+            "starships",
             0.005,
             0.01,
             2000,
@@ -376,8 +383,7 @@ def test_load_config_with_all_assets():
             10000,
         ),
         (
-            "profession_has_speeders",
-            "profession_speeders_net_value",
+            "speeders",
             0.015,
             0.05,
             300,
@@ -386,8 +392,7 @@ def test_load_config_with_all_assets():
             1500,
         ),
         (
-            "profession_has_other_vehicles",
-            "profession_other_vehicles_net_value",
+            "other_vehicles",
             0.01,
             0.03,
             400,
@@ -396,8 +401,7 @@ def test_load_config_with_all_assets():
             2000,
         ),
         (
-            "profession_has_luxury_property",
-            "profession_luxury_property_net_value",
+            "luxury_property",
             0.008,
             0.02,
             3000,
@@ -406,8 +410,7 @@ def test_load_config_with_all_assets():
             15000,
         ),
         (
-            "profession_has_galactic_stock",
-            "profession_galactic_stock_net_value",
+            "galactic_stock",
             0.012,
             0.04,
             800,
@@ -416,8 +419,7 @@ def test_load_config_with_all_assets():
             4000,
         ),
         (
-            "profession_has_business",
-            "profession_business_net_value",
+            "business",
             0.01,
             0.03,
             2500,
@@ -428,8 +430,7 @@ def test_load_config_with_all_assets():
     ]
 
     for (
-        has_field,
-        value_field,
+        asset_type,
         ownership_slope,
         ownership_intercept,
         value_slope,
@@ -438,14 +439,14 @@ def test_load_config_with_all_assets():
         noise_intercept,
     ) in asset_configs:
         # Test ownership config
-        has_config = getattr(config, has_field)["farmer"]
+        has_config = config.profession_has[asset_type]["farmer"]
         assert has_config.field_name == "age"
         assert has_config.mean_function.type == "linear"
         assert has_config.mean_function.params.slope == ownership_slope
         assert has_config.mean_function.params.intercept == ownership_intercept
 
         # Test value config
-        value_config = getattr(config, value_field)["farmer"]
+        value_config = config.profession_value[asset_type]["farmer"]
         assert value_config.field_name == "age"
         assert value_config.mean_function.type == "linear"
         assert value_config.mean_function.params.slope == value_slope

--- a/test/world_builder/test_net_worth_config.py
+++ b/test/world_builder/test_net_worth_config.py
@@ -286,19 +286,32 @@ def test_load_large_config():
 
 def test_load_config_with_primary_residence():
     """
-    Test loading a config file that includes the optional profession_primary_residence field.
+    Test loading a config file that includes the optional primary residence fields.
     """
     config_path = CONFIG_DIR / "nw_config_small.json"
     config = load_config(config_path)
 
     # Test basic structure
     assert isinstance(config, NetWorthConfig)
-    assert config.profession_primary_residence is not None
-    assert "farmer" in config.profession_primary_residence
+    assert config.profession_has_primary_residence is not None
+    assert config.profession_primary_residence_value is not None
+    assert "farmer" in config.profession_has_primary_residence
+    assert "farmer" in config.profession_primary_residence_value
 
-    # Test residence config structure
-    residence_config = config.profession_primary_residence["farmer"]
+    # Test residence ownership config structure
+    residence_config = config.profession_has_primary_residence["farmer"]
     assert residence_config.field_name == "age"
     assert residence_config.mean_function.type == "linear"
     assert residence_config.mean_function.params.slope == 0.02
     assert residence_config.mean_function.params.intercept == 0.1
+
+    # Test residence value config structure
+    value_config = config.profession_primary_residence_value["farmer"]
+    assert value_config.field_name == "age"
+    assert value_config.mean_function.type == "linear"
+    assert value_config.mean_function.params.slope == 1000
+    assert value_config.mean_function.params.intercept == 50000
+    assert value_config.noise_function.type == "normal"
+    assert value_config.noise_function.params["scale_factor"].type == "linear"
+    assert value_config.noise_function.params["scale_factor"].params.slope == 100
+    assert value_config.noise_function.params["scale_factor"].params.intercept == 5000

--- a/test/world_builder/test_net_worth_config.py
+++ b/test/world_builder/test_net_worth_config.py
@@ -282,3 +282,23 @@ def test_load_large_config():
         # Verify required parameters exist
         assert "field_name" in dist.noise_function.params
         assert "scale_factor" in dist.noise_function.params
+
+
+def test_load_config_with_primary_residence():
+    """
+    Test loading a config file that includes the optional profession_primary_residence field.
+    """
+    config_path = CONFIG_DIR / "nw_config_small.json"
+    config = load_config(config_path)
+
+    # Test basic structure
+    assert isinstance(config, NetWorthConfig)
+    assert config.profession_primary_residence is not None
+    assert "farmer" in config.profession_primary_residence
+
+    # Test residence config structure
+    residence_config = config.profession_primary_residence["farmer"]
+    assert residence_config.field_name == "age"
+    assert residence_config.mean_function.type == "linear"
+    assert residence_config.mean_function.params.slope == 0.02
+    assert residence_config.mean_function.params.intercept == 0.1

--- a/test/world_builder/test_net_worth_config.py
+++ b/test/world_builder/test_net_worth_config.py
@@ -315,3 +315,148 @@ def test_load_config_with_primary_residence():
     assert value_config.noise_function.params["scale_factor"].type == "linear"
     assert value_config.noise_function.params["scale_factor"].params.slope == 100
     assert value_config.noise_function.params["scale_factor"].params.intercept == 5000
+
+
+def test_load_config_with_all_assets():
+    """
+    Test loading a config file that includes all the optional asset fields.
+    """
+    config_path = CONFIG_DIR / "nw_config_small.json"
+    config = load_config(config_path)
+
+    # Test basic structure
+    assert isinstance(config, NetWorthConfig)
+    assert config.profession_has_primary_residence is not None
+    assert config.profession_primary_residence_value is not None
+    assert config.profession_has_other_properties is not None
+    assert config.profession_other_properties_net_value is not None
+    assert config.profession_has_starships is not None
+    assert config.profession_starships_net_value is not None
+    assert config.profession_has_speeders is not None
+    assert config.profession_speeders_net_value is not None
+    assert config.profession_has_other_vehicles is not None
+    assert config.profession_other_vehicles_net_value is not None
+    assert config.profession_has_luxury_property is not None
+    assert config.profession_luxury_property_net_value is not None
+    assert config.profession_has_galactic_stock is not None
+    assert config.profession_galactic_stock_net_value is not None
+    assert config.profession_has_business is not None
+    assert config.profession_business_net_value is not None
+
+    # Test that each asset type has the correct structure for "farmer" profession
+    asset_configs = [
+        (
+            "profession_has_primary_residence",
+            "profession_primary_residence_value",
+            0.02,
+            0.1,
+            1000,
+            50000,
+            100,
+            5000,
+        ),  # ownership_slope, ownership_intercept, value_slope, value_intercept, noise_slope, noise_intercept
+        (
+            "profession_has_other_properties",
+            "profession_other_properties_net_value",
+            0.01,
+            0.05,
+            500,
+            25000,
+            50,
+            2500,
+        ),
+        (
+            "profession_has_starships",
+            "profession_starships_net_value",
+            0.005,
+            0.01,
+            2000,
+            100000,
+            200,
+            10000,
+        ),
+        (
+            "profession_has_speeders",
+            "profession_speeders_net_value",
+            0.015,
+            0.05,
+            300,
+            15000,
+            30,
+            1500,
+        ),
+        (
+            "profession_has_other_vehicles",
+            "profession_other_vehicles_net_value",
+            0.01,
+            0.03,
+            400,
+            20000,
+            40,
+            2000,
+        ),
+        (
+            "profession_has_luxury_property",
+            "profession_luxury_property_net_value",
+            0.008,
+            0.02,
+            3000,
+            150000,
+            300,
+            15000,
+        ),
+        (
+            "profession_has_galactic_stock",
+            "profession_galactic_stock_net_value",
+            0.012,
+            0.04,
+            800,
+            40000,
+            80,
+            4000,
+        ),
+        (
+            "profession_has_business",
+            "profession_business_net_value",
+            0.01,
+            0.03,
+            2500,
+            125000,
+            250,
+            12500,
+        ),
+    ]
+
+    for (
+        has_field,
+        value_field,
+        ownership_slope,
+        ownership_intercept,
+        value_slope,
+        value_intercept,
+        noise_slope,
+        noise_intercept,
+    ) in asset_configs:
+        # Test ownership config
+        has_config = getattr(config, has_field)["farmer"]
+        assert has_config.field_name == "age"
+        assert has_config.mean_function.type == "linear"
+        assert has_config.mean_function.params.slope == ownership_slope
+        assert has_config.mean_function.params.intercept == ownership_intercept
+
+        # Test value config
+        value_config = getattr(config, value_field)["farmer"]
+        assert value_config.field_name == "age"
+        assert value_config.mean_function.type == "linear"
+        assert value_config.mean_function.params.slope == value_slope
+        assert value_config.mean_function.params.intercept == value_intercept
+        assert value_config.noise_function.type == "normal"
+        assert value_config.noise_function.params["scale_factor"].type == "linear"
+        assert (
+            value_config.noise_function.params["scale_factor"].params.slope
+            == noise_slope
+        )
+        assert (
+            value_config.noise_function.params["scale_factor"].params.intercept
+            == noise_intercept
+        )

--- a/test/world_builder/test_net_worth_generator.py
+++ b/test/world_builder/test_net_worth_generator.py
@@ -78,7 +78,11 @@ def test_networth_creation():
 def test_networth_immutability():
     """Test that NetWorth objects are immutable through properties."""
     net_worth = NetWorth(
-        chain_code="TEST123", liquid_currency=1000.0, currency_type="credits"
+        chain_code="TEST123",
+        liquid_currency=1000.0,
+        currency_type="credits",
+        owns_primary_residence=True,
+        primary_residence_value=50000.0,
     )
 
     # Test that we can't set attributes directly
@@ -89,33 +93,17 @@ def test_networth_immutability():
     with pytest.raises(AttributeError):
         net_worth.currency_type = "imperial_credits"
     with pytest.raises(AttributeError):
-        net_worth.owns_other_properties = True
+        net_worth.owns_primary_residence = False
     with pytest.raises(AttributeError):
-        net_worth.other_properties_net_value = 25000.0
+        net_worth.primary_residence_value = 75000.0
+
+    # Test that we can't add new attributes after initialization
     with pytest.raises(AttributeError):
-        net_worth.owns_starships = True
+        net_worth.new_attribute = "value"
     with pytest.raises(AttributeError):
-        net_worth.starships_net_value = 100000.0
+        net_worth.owns_new_asset = True
     with pytest.raises(AttributeError):
-        net_worth.owns_speeders = True
-    with pytest.raises(AttributeError):
-        net_worth.speeders_net_value = 15000.0
-    with pytest.raises(AttributeError):
-        net_worth.owns_other_vehicles = True
-    with pytest.raises(AttributeError):
-        net_worth.other_vehicles_net_value = 20000.0
-    with pytest.raises(AttributeError):
-        net_worth.owns_luxury_property = True
-    with pytest.raises(AttributeError):
-        net_worth.luxury_property_net_value = 150000.0
-    with pytest.raises(AttributeError):
-        net_worth.owns_galactic_stock = True
-    with pytest.raises(AttributeError):
-        net_worth.galactic_stock_net_value = 40000.0
-    with pytest.raises(AttributeError):
-        net_worth.owns_business = True
-    with pytest.raises(AttributeError):
-        net_worth.business_net_value = 125000.0
+        net_worth.new_asset_value = 100000.0
 
 
 def test_networth_equality():
@@ -215,18 +203,39 @@ def test_networth_repr():
         business_net_value=125000.0,
     )
 
-    expected_repr = (
-        "NetWorth(chain_code='TEST123', liquid_currency=1000.0, currency_type='credits', "
-        "owns_primary_residence=True, primary_residence_value=50000.0, "
-        "owns_other_properties=True, other_properties_net_value=25000.0, "
-        "owns_starships=True, starships_net_value=100000.0, "
-        "owns_speeders=True, speeders_net_value=15000.0, "
-        "owns_other_vehicles=True, other_vehicles_net_value=20000.0, "
-        "owns_luxury_property=True, luxury_property_net_value=150000.0, "
-        "owns_galactic_stock=True, galactic_stock_net_value=40000.0, "
-        "owns_business=True, business_net_value=125000.0)"
-    )
-    assert repr(net_worth) == expected_repr
+    repr_str = repr(net_worth)
+
+    # Check that it starts with NetWorth( and ends with )
+    assert repr_str.startswith("NetWorth(")
+    assert repr_str.endswith(")")
+
+    # Check that all expected attributes are present in the repr
+    expected_attrs = [
+        "chain_code='TEST123'",
+        "liquid_currency=1000.0",
+        "currency_type='credits'",
+        "owns_primary_residence=True",
+        "primary_residence_value=50000.0",
+        "owns_other_properties=True",
+        "other_properties_net_value=25000.0",
+        "owns_starships=True",
+        "starships_net_value=100000.0",
+        "owns_speeders=True",
+        "speeders_net_value=15000.0",
+        "owns_other_vehicles=True",
+        "other_vehicles_net_value=20000.0",
+        "owns_luxury_property=True",
+        "luxury_property_net_value=150000.0",
+        "owns_galactic_stock=True",
+        "galactic_stock_net_value=40000.0",
+        "owns_business=True",
+        "business_net_value=125000.0",
+    ]
+
+    for attr in expected_attrs:
+        assert (
+            attr in repr_str
+        ), f"Expected attribute {attr} not found in repr: {repr_str}"
 
 
 def test_generate_net_worth_basic():

--- a/test/world_builder/test_net_worth_generator.py
+++ b/test/world_builder/test_net_worth_generator.py
@@ -443,213 +443,217 @@ def test_generate_net_worth_with_all_assets():
                 ),
             )
         },
-        profession_has_primary_residence={
-            "farmer": BernoulliBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=0.02, intercept=0.1)
-                ),
-            )
+        profession_has={
+            "primary_residence": {
+                "farmer": BernoulliBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=0.02, intercept=0.1)
+                    ),
+                )
+            },
+            "other_properties": {
+                "farmer": BernoulliBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=0.01, intercept=0.05)
+                    ),
+                )
+            },
+            "starships": {
+                "farmer": BernoulliBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=0.005, intercept=0.01)
+                    ),
+                )
+            },
+            "speeders": {
+                "farmer": BernoulliBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=0.015, intercept=0.05)
+                    ),
+                )
+            },
+            "other_vehicles": {
+                "farmer": BernoulliBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=0.01, intercept=0.03)
+                    ),
+                )
+            },
+            "luxury_property": {
+                "farmer": BernoulliBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=0.008, intercept=0.02)
+                    ),
+                )
+            },
+            "galactic_stock": {
+                "farmer": BernoulliBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=0.012, intercept=0.04)
+                    ),
+                )
+            },
+            "business": {
+                "farmer": BernoulliBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=0.01, intercept=0.03)
+                    ),
+                )
+            },
         },
-        profession_primary_residence_value={
-            "farmer": FunctionBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=1000, intercept=50000)
-                ),
-                noise_function=NoiseFunctionConfig(
-                    type="normal",
-                    params={
-                        "field_name": "age",
-                        "scale_factor": FunctionConfig(
-                            type="linear",
-                            params=LinearParams(slope=100, intercept=5000),
-                        ),
-                    },
-                ),
-            )
-        },
-        profession_has_other_properties={
-            "farmer": BernoulliBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=0.01, intercept=0.05)
-                ),
-            )
-        },
-        profession_other_properties_net_value={
-            "farmer": FunctionBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=500, intercept=25000)
-                ),
-                noise_function=NoiseFunctionConfig(
-                    type="normal",
-                    params={
-                        "field_name": "age",
-                        "scale_factor": FunctionConfig(
-                            type="linear",
-                            params=LinearParams(slope=50, intercept=2500),
-                        ),
-                    },
-                ),
-            )
-        },
-        profession_has_starships={
-            "farmer": BernoulliBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=0.005, intercept=0.01)
-                ),
-            )
-        },
-        profession_starships_net_value={
-            "farmer": FunctionBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=2000, intercept=100000)
-                ),
-                noise_function=NoiseFunctionConfig(
-                    type="normal",
-                    params={
-                        "field_name": "age",
-                        "scale_factor": FunctionConfig(
-                            type="linear",
-                            params=LinearParams(slope=200, intercept=10000),
-                        ),
-                    },
-                ),
-            )
-        },
-        profession_has_speeders={
-            "farmer": BernoulliBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=0.015, intercept=0.05)
-                ),
-            )
-        },
-        profession_speeders_net_value={
-            "farmer": FunctionBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=300, intercept=15000)
-                ),
-                noise_function=NoiseFunctionConfig(
-                    type="normal",
-                    params={
-                        "field_name": "age",
-                        "scale_factor": FunctionConfig(
-                            type="linear",
-                            params=LinearParams(slope=30, intercept=1500),
-                        ),
-                    },
-                ),
-            )
-        },
-        profession_has_other_vehicles={
-            "farmer": BernoulliBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=0.01, intercept=0.03)
-                ),
-            )
-        },
-        profession_other_vehicles_net_value={
-            "farmer": FunctionBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=400, intercept=20000)
-                ),
-                noise_function=NoiseFunctionConfig(
-                    type="normal",
-                    params={
-                        "field_name": "age",
-                        "scale_factor": FunctionConfig(
-                            type="linear",
-                            params=LinearParams(slope=40, intercept=2000),
-                        ),
-                    },
-                ),
-            )
-        },
-        profession_has_luxury_property={
-            "farmer": BernoulliBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=0.008, intercept=0.02)
-                ),
-            )
-        },
-        profession_luxury_property_net_value={
-            "farmer": FunctionBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=3000, intercept=150000)
-                ),
-                noise_function=NoiseFunctionConfig(
-                    type="normal",
-                    params={
-                        "field_name": "age",
-                        "scale_factor": FunctionConfig(
-                            type="linear",
-                            params=LinearParams(slope=300, intercept=15000),
-                        ),
-                    },
-                ),
-            )
-        },
-        profession_has_galactic_stock={
-            "farmer": BernoulliBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=0.012, intercept=0.04)
-                ),
-            )
-        },
-        profession_galactic_stock_net_value={
-            "farmer": FunctionBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=800, intercept=40000)
-                ),
-                noise_function=NoiseFunctionConfig(
-                    type="normal",
-                    params={
-                        "field_name": "age",
-                        "scale_factor": FunctionConfig(
-                            type="linear",
-                            params=LinearParams(slope=80, intercept=4000),
-                        ),
-                    },
-                ),
-            )
-        },
-        profession_has_business={
-            "farmer": BernoulliBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=0.01, intercept=0.03)
-                ),
-            )
-        },
-        profession_business_net_value={
-            "farmer": FunctionBasedDist(
-                field_name="age",
-                mean_function=FunctionConfig(
-                    type="linear", params=LinearParams(slope=2500, intercept=125000)
-                ),
-                noise_function=NoiseFunctionConfig(
-                    type="normal",
-                    params={
-                        "field_name": "age",
-                        "scale_factor": FunctionConfig(
-                            type="linear",
-                            params=LinearParams(slope=250, intercept=12500),
-                        ),
-                    },
-                ),
-            )
+        profession_value={
+            "primary_residence": {
+                "farmer": FunctionBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=1000, intercept=50000)
+                    ),
+                    noise_function=NoiseFunctionConfig(
+                        type="normal",
+                        params={
+                            "field_name": "age",
+                            "scale_factor": FunctionConfig(
+                                type="linear",
+                                params=LinearParams(slope=100, intercept=5000),
+                            ),
+                        },
+                    ),
+                )
+            },
+            "other_properties": {
+                "farmer": FunctionBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=500, intercept=25000)
+                    ),
+                    noise_function=NoiseFunctionConfig(
+                        type="normal",
+                        params={
+                            "field_name": "age",
+                            "scale_factor": FunctionConfig(
+                                type="linear",
+                                params=LinearParams(slope=50, intercept=2500),
+                            ),
+                        },
+                    ),
+                )
+            },
+            "starships": {
+                "farmer": FunctionBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=2000, intercept=100000)
+                    ),
+                    noise_function=NoiseFunctionConfig(
+                        type="normal",
+                        params={
+                            "field_name": "age",
+                            "scale_factor": FunctionConfig(
+                                type="linear",
+                                params=LinearParams(slope=200, intercept=10000),
+                            ),
+                        },
+                    ),
+                )
+            },
+            "speeders": {
+                "farmer": FunctionBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=300, intercept=15000)
+                    ),
+                    noise_function=NoiseFunctionConfig(
+                        type="normal",
+                        params={
+                            "field_name": "age",
+                            "scale_factor": FunctionConfig(
+                                type="linear",
+                                params=LinearParams(slope=30, intercept=1500),
+                            ),
+                        },
+                    ),
+                )
+            },
+            "other_vehicles": {
+                "farmer": FunctionBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=400, intercept=20000)
+                    ),
+                    noise_function=NoiseFunctionConfig(
+                        type="normal",
+                        params={
+                            "field_name": "age",
+                            "scale_factor": FunctionConfig(
+                                type="linear",
+                                params=LinearParams(slope=40, intercept=2000),
+                            ),
+                        },
+                    ),
+                )
+            },
+            "luxury_property": {
+                "farmer": FunctionBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=3000, intercept=150000)
+                    ),
+                    noise_function=NoiseFunctionConfig(
+                        type="normal",
+                        params={
+                            "field_name": "age",
+                            "scale_factor": FunctionConfig(
+                                type="linear",
+                                params=LinearParams(slope=300, intercept=15000),
+                            ),
+                        },
+                    ),
+                )
+            },
+            "galactic_stock": {
+                "farmer": FunctionBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=800, intercept=40000)
+                    ),
+                    noise_function=NoiseFunctionConfig(
+                        type="normal",
+                        params={
+                            "field_name": "age",
+                            "scale_factor": FunctionConfig(
+                                type="linear",
+                                params=LinearParams(slope=80, intercept=4000),
+                            ),
+                        },
+                    ),
+                )
+            },
+            "business": {
+                "farmer": FunctionBasedDist(
+                    field_name="age",
+                    mean_function=FunctionConfig(
+                        type="linear", params=LinearParams(slope=2500, intercept=125000)
+                    ),
+                    noise_function=NoiseFunctionConfig(
+                        type="normal",
+                        params={
+                            "field_name": "age",
+                            "scale_factor": FunctionConfig(
+                                type="linear",
+                                params=LinearParams(slope=250, intercept=12500),
+                            ),
+                        },
+                    ),
+                )
+            },
         },
         metadata={"currency": "credits"},
     )
@@ -661,23 +665,81 @@ def test_generate_net_worth_with_all_assets():
     asset_configs = [
         (
             "owns_primary_residence",
+            "primary_residence_value",
             0.02,
             30,
             0.1,
             1000,
             50000,
         ),  # slope, age, intercept, value_slope, value_intercept
-        ("owns_other_properties", 0.01, 30, 0.05, 500, 25000),
-        ("owns_starships", 0.005, 30, 0.01, 2000, 100000),
-        ("owns_speeders", 0.015, 30, 0.05, 300, 15000),
-        ("owns_other_vehicles", 0.01, 30, 0.03, 400, 20000),
-        ("owns_luxury_property", 0.008, 30, 0.02, 3000, 150000),
-        ("owns_galactic_stock", 0.012, 30, 0.04, 800, 40000),
-        ("owns_business", 0.01, 30, 0.03, 2500, 125000),
+        (
+            "owns_other_properties",
+            "other_properties_net_value",
+            0.01,
+            30,
+            0.05,
+            500,
+            25000,
+        ),
+        (
+            "owns_starships",
+            "starships_net_value",
+            0.005,
+            30,
+            0.01,
+            2000,
+            100000,
+        ),
+        (
+            "owns_speeders",
+            "speeders_net_value",
+            0.015,
+            30,
+            0.05,
+            300,
+            15000,
+        ),
+        (
+            "owns_other_vehicles",
+            "other_vehicles_net_value",
+            0.01,
+            30,
+            0.03,
+            400,
+            20000,
+        ),
+        (
+            "owns_luxury_property",
+            "luxury_property_net_value",
+            0.008,
+            30,
+            0.02,
+            3000,
+            150000,
+        ),
+        (
+            "owns_galactic_stock",
+            "galactic_stock_net_value",
+            0.012,
+            30,
+            0.04,
+            800,
+            40000,
+        ),
+        (
+            "owns_business",
+            "business_net_value",
+            0.01,
+            30,
+            0.03,
+            2500,
+            125000,
+        ),
     ]
 
     for (
-        asset_name,
+        owns_attr,
+        value_attr,
         slope,
         age,
         intercept,
@@ -686,28 +748,13 @@ def test_generate_net_worth_with_all_assets():
     ) in asset_configs:
         # Check ownership probability
         expected_probability = slope * age + intercept
-        true_count = sum(1 for r in results if getattr(r, asset_name))
+        true_count = sum(1 for r in results if getattr(r, owns_attr))
         actual_probability = true_count / len(results)
+        # Allow for 5% variation from expected probability
         assert abs(actual_probability - expected_probability) < 0.05
 
         # Check value distribution for owned assets
-        value_name = asset_name.replace("owns_", "") + "_value"
-        if asset_name == "owns_other_properties":
-            value_name = "other_properties_net_value"
-        elif asset_name == "owns_starships":
-            value_name = "starships_net_value"
-        elif asset_name == "owns_speeders":
-            value_name = "speeders_net_value"
-        elif asset_name == "owns_other_vehicles":
-            value_name = "other_vehicles_net_value"
-        elif asset_name == "owns_luxury_property":
-            value_name = "luxury_property_net_value"
-        elif asset_name == "owns_galactic_stock":
-            value_name = "galactic_stock_net_value"
-        elif asset_name == "owns_business":
-            value_name = "business_net_value"
-
-        values = [getattr(r, value_name) for r in results if getattr(r, asset_name)]
+        values = [getattr(r, value_attr) for r in results if getattr(r, owns_attr)]
         if values:  # Only check if we have some values
             expected_mean = value_slope * age + value_intercept
             actual_mean = sum(values) / len(values)

--- a/test/world_builder/test_net_worth_generator.py
+++ b/test/world_builder/test_net_worth_generator.py
@@ -38,6 +38,20 @@ def test_networth_creation():
         currency_type="credits",
         owns_primary_residence=True,
         primary_residence_value=50000.0,
+        owns_other_properties=True,
+        other_properties_net_value=25000.0,
+        owns_starships=True,
+        starships_net_value=100000.0,
+        owns_speeders=True,
+        speeders_net_value=15000.0,
+        owns_other_vehicles=True,
+        other_vehicles_net_value=20000.0,
+        owns_luxury_property=True,
+        luxury_property_net_value=150000.0,
+        owns_galactic_stock=True,
+        galactic_stock_net_value=40000.0,
+        owns_business=True,
+        business_net_value=125000.0,
     )
 
     assert net_worth.chain_code == "TEST123"
@@ -45,6 +59,20 @@ def test_networth_creation():
     assert net_worth.currency_type == "credits"
     assert net_worth.owns_primary_residence is True
     assert net_worth.primary_residence_value == 50000.0
+    assert net_worth.owns_other_properties is True
+    assert net_worth.other_properties_net_value == 25000.0
+    assert net_worth.owns_starships is True
+    assert net_worth.starships_net_value == 100000.0
+    assert net_worth.owns_speeders is True
+    assert net_worth.speeders_net_value == 15000.0
+    assert net_worth.owns_other_vehicles is True
+    assert net_worth.other_vehicles_net_value == 20000.0
+    assert net_worth.owns_luxury_property is True
+    assert net_worth.luxury_property_net_value == 150000.0
+    assert net_worth.owns_galactic_stock is True
+    assert net_worth.galactic_stock_net_value == 40000.0
+    assert net_worth.owns_business is True
+    assert net_worth.business_net_value == 125000.0
 
 
 def test_networth_immutability():
@@ -60,20 +88,102 @@ def test_networth_immutability():
         net_worth.liquid_currency = 2000.0
     with pytest.raises(AttributeError):
         net_worth.currency_type = "imperial_credits"
+    with pytest.raises(AttributeError):
+        net_worth.owns_other_properties = True
+    with pytest.raises(AttributeError):
+        net_worth.other_properties_net_value = 25000.0
+    with pytest.raises(AttributeError):
+        net_worth.owns_starships = True
+    with pytest.raises(AttributeError):
+        net_worth.starships_net_value = 100000.0
+    with pytest.raises(AttributeError):
+        net_worth.owns_speeders = True
+    with pytest.raises(AttributeError):
+        net_worth.speeders_net_value = 15000.0
+    with pytest.raises(AttributeError):
+        net_worth.owns_other_vehicles = True
+    with pytest.raises(AttributeError):
+        net_worth.other_vehicles_net_value = 20000.0
+    with pytest.raises(AttributeError):
+        net_worth.owns_luxury_property = True
+    with pytest.raises(AttributeError):
+        net_worth.luxury_property_net_value = 150000.0
+    with pytest.raises(AttributeError):
+        net_worth.owns_galactic_stock = True
+    with pytest.raises(AttributeError):
+        net_worth.galactic_stock_net_value = 40000.0
+    with pytest.raises(AttributeError):
+        net_worth.owns_business = True
+    with pytest.raises(AttributeError):
+        net_worth.business_net_value = 125000.0
 
 
 def test_networth_equality():
     """Test that NetWorth objects can be compared for equality."""
     net_worth1 = NetWorth(
-        chain_code="TEST123", liquid_currency=1000.0, currency_type="credits"
+        chain_code="TEST123",
+        liquid_currency=1000.0,
+        currency_type="credits",
+        owns_primary_residence=True,
+        primary_residence_value=50000.0,
+        owns_other_properties=True,
+        other_properties_net_value=25000.0,
+        owns_starships=True,
+        starships_net_value=100000.0,
+        owns_speeders=True,
+        speeders_net_value=15000.0,
+        owns_other_vehicles=True,
+        other_vehicles_net_value=20000.0,
+        owns_luxury_property=True,
+        luxury_property_net_value=150000.0,
+        owns_galactic_stock=True,
+        galactic_stock_net_value=40000.0,
+        owns_business=True,
+        business_net_value=125000.0,
     )
 
     net_worth2 = NetWorth(
-        chain_code="TEST123", liquid_currency=1000.0, currency_type="credits"
+        chain_code="TEST123",
+        liquid_currency=1000.0,
+        currency_type="credits",
+        owns_primary_residence=True,
+        primary_residence_value=50000.0,
+        owns_other_properties=True,
+        other_properties_net_value=25000.0,
+        owns_starships=True,
+        starships_net_value=100000.0,
+        owns_speeders=True,
+        speeders_net_value=15000.0,
+        owns_other_vehicles=True,
+        other_vehicles_net_value=20000.0,
+        owns_luxury_property=True,
+        luxury_property_net_value=150000.0,
+        owns_galactic_stock=True,
+        galactic_stock_net_value=40000.0,
+        owns_business=True,
+        business_net_value=125000.0,
     )
 
     net_worth3 = NetWorth(
-        chain_code="TEST456", liquid_currency=1000.0, currency_type="credits"
+        chain_code="TEST456",
+        liquid_currency=1000.0,
+        currency_type="credits",
+        owns_primary_residence=True,
+        primary_residence_value=50000.0,
+        owns_other_properties=True,
+        other_properties_net_value=25000.0,
+        owns_starships=True,
+        starships_net_value=100000.0,
+        owns_speeders=True,
+        speeders_net_value=15000.0,
+        owns_other_vehicles=True,
+        other_vehicles_net_value=20000.0,
+        owns_luxury_property=True,
+        luxury_property_net_value=150000.0,
+        owns_galactic_stock=True,
+        galactic_stock_net_value=40000.0,
+        owns_business=True,
+        business_net_value=125000.0,
     )
 
     assert net_worth1 == net_worth2
@@ -84,10 +194,38 @@ def test_networth_equality():
 def test_networth_repr():
     """Test the string representation of NetWorth objects."""
     net_worth = NetWorth(
-        chain_code="TEST123", liquid_currency=1000.0, currency_type="credits"
+        chain_code="TEST123",
+        liquid_currency=1000.0,
+        currency_type="credits",
+        owns_primary_residence=True,
+        primary_residence_value=50000.0,
+        owns_other_properties=True,
+        other_properties_net_value=25000.0,
+        owns_starships=True,
+        starships_net_value=100000.0,
+        owns_speeders=True,
+        speeders_net_value=15000.0,
+        owns_other_vehicles=True,
+        other_vehicles_net_value=20000.0,
+        owns_luxury_property=True,
+        luxury_property_net_value=150000.0,
+        owns_galactic_stock=True,
+        galactic_stock_net_value=40000.0,
+        owns_business=True,
+        business_net_value=125000.0,
     )
 
-    expected_repr = "NetWorth(chain_code='TEST123', liquid_currency=1000.0, currency_type='credits')"
+    expected_repr = (
+        "NetWorth(chain_code='TEST123', liquid_currency=1000.0, currency_type='credits', "
+        "owns_primary_residence=True, primary_residence_value=50000.0, "
+        "owns_other_properties=True, other_properties_net_value=25000.0, "
+        "owns_starships=True, starships_net_value=100000.0, "
+        "owns_speeders=True, speeders_net_value=15000.0, "
+        "owns_other_vehicles=True, other_vehicles_net_value=20000.0, "
+        "owns_luxury_property=True, luxury_property_net_value=150000.0, "
+        "owns_galactic_stock=True, galactic_stock_net_value=40000.0, "
+        "owns_business=True, business_net_value=125000.0)"
+    )
     assert repr(net_worth) == expected_repr
 
 
@@ -281,12 +419,12 @@ def test_generate_net_worth_constant():
         assert net_worth.currency_type == "imperial_credits"
 
 
-def test_generate_net_worth_with_primary_residence():
-    """Test net worth generation with primary residence probability and value."""
+def test_generate_net_worth_with_all_assets():
+    """Test net worth generation with all asset types."""
     # Create a mock character
     character = MockCharacter(chain_code="TEST123", profession="farmer", age=30)
 
-    # Create a config with primary residence probability and value
+    # Create a config with all asset types
     config = NetWorthConfig(
         profession_liquid_currency={
             "farmer": FunctionBasedDist(
@@ -331,27 +469,247 @@ def test_generate_net_worth_with_primary_residence():
                 ),
             )
         },
+        profession_has_other_properties={
+            "farmer": BernoulliBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=0.01, intercept=0.05)
+                ),
+            )
+        },
+        profession_other_properties_net_value={
+            "farmer": FunctionBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=500, intercept=25000)
+                ),
+                noise_function=NoiseFunctionConfig(
+                    type="normal",
+                    params={
+                        "field_name": "age",
+                        "scale_factor": FunctionConfig(
+                            type="linear",
+                            params=LinearParams(slope=50, intercept=2500),
+                        ),
+                    },
+                ),
+            )
+        },
+        profession_has_starships={
+            "farmer": BernoulliBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=0.005, intercept=0.01)
+                ),
+            )
+        },
+        profession_starships_net_value={
+            "farmer": FunctionBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=2000, intercept=100000)
+                ),
+                noise_function=NoiseFunctionConfig(
+                    type="normal",
+                    params={
+                        "field_name": "age",
+                        "scale_factor": FunctionConfig(
+                            type="linear",
+                            params=LinearParams(slope=200, intercept=10000),
+                        ),
+                    },
+                ),
+            )
+        },
+        profession_has_speeders={
+            "farmer": BernoulliBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=0.015, intercept=0.05)
+                ),
+            )
+        },
+        profession_speeders_net_value={
+            "farmer": FunctionBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=300, intercept=15000)
+                ),
+                noise_function=NoiseFunctionConfig(
+                    type="normal",
+                    params={
+                        "field_name": "age",
+                        "scale_factor": FunctionConfig(
+                            type="linear",
+                            params=LinearParams(slope=30, intercept=1500),
+                        ),
+                    },
+                ),
+            )
+        },
+        profession_has_other_vehicles={
+            "farmer": BernoulliBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=0.01, intercept=0.03)
+                ),
+            )
+        },
+        profession_other_vehicles_net_value={
+            "farmer": FunctionBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=400, intercept=20000)
+                ),
+                noise_function=NoiseFunctionConfig(
+                    type="normal",
+                    params={
+                        "field_name": "age",
+                        "scale_factor": FunctionConfig(
+                            type="linear",
+                            params=LinearParams(slope=40, intercept=2000),
+                        ),
+                    },
+                ),
+            )
+        },
+        profession_has_luxury_property={
+            "farmer": BernoulliBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=0.008, intercept=0.02)
+                ),
+            )
+        },
+        profession_luxury_property_net_value={
+            "farmer": FunctionBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=3000, intercept=150000)
+                ),
+                noise_function=NoiseFunctionConfig(
+                    type="normal",
+                    params={
+                        "field_name": "age",
+                        "scale_factor": FunctionConfig(
+                            type="linear",
+                            params=LinearParams(slope=300, intercept=15000),
+                        ),
+                    },
+                ),
+            )
+        },
+        profession_has_galactic_stock={
+            "farmer": BernoulliBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=0.012, intercept=0.04)
+                ),
+            )
+        },
+        profession_galactic_stock_net_value={
+            "farmer": FunctionBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=800, intercept=40000)
+                ),
+                noise_function=NoiseFunctionConfig(
+                    type="normal",
+                    params={
+                        "field_name": "age",
+                        "scale_factor": FunctionConfig(
+                            type="linear",
+                            params=LinearParams(slope=80, intercept=4000),
+                        ),
+                    },
+                ),
+            )
+        },
+        profession_has_business={
+            "farmer": BernoulliBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=0.01, intercept=0.03)
+                ),
+            )
+        },
+        profession_business_net_value={
+            "farmer": FunctionBasedDist(
+                field_name="age",
+                mean_function=FunctionConfig(
+                    type="linear", params=LinearParams(slope=2500, intercept=125000)
+                ),
+                noise_function=NoiseFunctionConfig(
+                    type="normal",
+                    params={
+                        "field_name": "age",
+                        "scale_factor": FunctionConfig(
+                            type="linear",
+                            params=LinearParams(slope=250, intercept=12500),
+                        ),
+                    },
+                ),
+            )
+        },
         metadata={"currency": "credits"},
     )
 
     # Generate net worth multiple times to test probability
     results = [generate_net_worth(character, config) for _ in range(1000)]
 
-    # For age=30, probability should be 0.02*30 + 0.1 = 0.7
-    # Count how many times primary residence is True
-    true_count = sum(1 for r in results if r.owns_primary_residence)
-    probability = true_count / len(results)
-
-    # Check that the probability is roughly what we expect (within 5%)
-    expected_probability = 0.02 * 30 + 0.1  # = 0.7
-    assert abs(probability - expected_probability) < 0.05
-
-    # For those that own a residence, check the value distribution
-    residence_values = [
-        r.primary_residence_value for r in results if r.owns_primary_residence
+    # For age=30, test each asset type's probability and value distribution
+    asset_configs = [
+        (
+            "owns_primary_residence",
+            0.02,
+            30,
+            0.1,
+            1000,
+            50000,
+        ),  # slope, age, intercept, value_slope, value_intercept
+        ("owns_other_properties", 0.01, 30, 0.05, 500, 25000),
+        ("owns_starships", 0.005, 30, 0.01, 2000, 100000),
+        ("owns_speeders", 0.015, 30, 0.05, 300, 15000),
+        ("owns_other_vehicles", 0.01, 30, 0.03, 400, 20000),
+        ("owns_luxury_property", 0.008, 30, 0.02, 3000, 150000),
+        ("owns_galactic_stock", 0.012, 30, 0.04, 800, 40000),
+        ("owns_business", 0.01, 30, 0.03, 2500, 125000),
     ]
-    assert len(residence_values) > 0  # Make sure we have some values to test
 
-    # For age=30, mean should be 1000*30 + 50000 = 80000
-    mean_value = sum(residence_values) / len(residence_values)
-    assert 70000 <= mean_value <= 90000  # Allow for some variation due to noise
+    for (
+        asset_name,
+        slope,
+        age,
+        intercept,
+        value_slope,
+        value_intercept,
+    ) in asset_configs:
+        # Check ownership probability
+        expected_probability = slope * age + intercept
+        true_count = sum(1 for r in results if getattr(r, asset_name))
+        actual_probability = true_count / len(results)
+        assert abs(actual_probability - expected_probability) < 0.05
+
+        # Check value distribution for owned assets
+        value_name = asset_name.replace("owns_", "") + "_value"
+        if asset_name == "owns_other_properties":
+            value_name = "other_properties_net_value"
+        elif asset_name == "owns_starships":
+            value_name = "starships_net_value"
+        elif asset_name == "owns_speeders":
+            value_name = "speeders_net_value"
+        elif asset_name == "owns_other_vehicles":
+            value_name = "other_vehicles_net_value"
+        elif asset_name == "owns_luxury_property":
+            value_name = "luxury_property_net_value"
+        elif asset_name == "owns_galactic_stock":
+            value_name = "galactic_stock_net_value"
+        elif asset_name == "owns_business":
+            value_name = "business_net_value"
+
+        values = [getattr(r, value_name) for r in results if getattr(r, asset_name)]
+        if values:  # Only check if we have some values
+            expected_mean = value_slope * age + value_intercept
+            actual_mean = sum(values) / len(values)
+            # Allow for 10% variation from expected mean
+            assert abs(actual_mean - expected_mean) / expected_mean < 0.1


### PR DESCRIPTION
This feature adds optional fields to net worth configs. Specifically, net worth configs now allow more fields under two top-level keys: "has" and "value." This enables things like "has_other_properties" and "other_properties_value." Some example configs are provided in the test and examples folder with these other fields.