### PR TITLE
Rebuild spatial model around layer/world abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,28 @@ python plot_ecosystem.py
 
 ![Ecosystem Species and Age Distributions](readme_example_plot.png)
 
+
+## Spatial data generation (experimental)
+
+A generalized spatial abstraction is available under `src/spatial_data_generation` following:
+
+- `Layer = (Domain, Features, Network)`
+- `World = (Layers, Portals)`
+
+Included reference scenarios:
+
+- Galaxy layer (topology-heavy graph over planar coordinates)
+- Planet layer (sphere/geodesic domain with city points)
+- City layer (flat 2D districts + street network)
+
+Try the multiscale example:
+
+```
+python examples/spatial_data_generation/multiscale_world_example.py
+```
+
+This writes `galaxy.png`, `planet_0.png`, and `city_0_0.png` locally.
+
 ## Docker
 
 The repository includes a **generation-only** image (no Streamlit). It installs the package from `pyproject.toml` via `uv` and exposes two entry modules:

--- a/examples/spatial_data_generation/city_flat_example.py
+++ b/examples/spatial_data_generation/city_flat_example.py
@@ -1,0 +1,17 @@
+"""Generate and plot a sample flat city layer."""
+
+from spatial_data_generation.city_flat import CitySpec, generate_flat_city_layer
+from spatial_data_generation.visualize import save_layer_plot
+
+
+def main() -> None:
+    city = generate_flat_city_layer("city_alpha", CitySpec(width=120, height=80, blocks_x=6, blocks_y=4))
+    save_layer_plot(city, "city_alpha.png", show_network=True)
+    print(
+        f"Generated layer '{city.id}' with {len(city.features)} features, "
+        f"{len(city.network.nodes)} nodes, and {len(city.network.edges)} edges."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/spatial_data_generation/multiscale_world_example.py
+++ b/examples/spatial_data_generation/multiscale_world_example.py
@@ -1,0 +1,15 @@
+"""Build a reference multiscale world and render each layer."""
+
+from spatial_data_generation.scenarios import build_reference_world
+from spatial_data_generation.visualize import save_layer_plot
+
+
+if __name__ == "__main__":
+    world = build_reference_world()
+
+    for layer in world.layers:
+        out = f"{layer.id}.png"
+        save_layer_plot(layer, out, show_network=True)
+        print(f"saved {out}")
+
+    print(f"layers={len(world.layers)} portals={len(world.portals)}")

--- a/src/spatial_data_generation/SPATIAL_IMPLEMENTATION_PLAN.md
+++ b/src/spatial_data_generation/SPATIAL_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,47 @@
+# Spatial Data Implementation Plan (v0)
+
+This plan operationalizes `SPATIAL_DATA_OVERVIEW.md` into an implementation sequence
+that minimizes lock-in while still delivering one complete vertical slice.
+
+## Candidate first vertical slices
+
+1. **City on flat 2D (recommended first)**
+   - Domain: plane (bounded)
+   - Features: roads and blocks
+   - Network: road intersection graph
+   - Why first: easiest geometry and strongest testability.
+
+2. **Galaxy as graph**
+   - Domain: abstract graph metric
+   - Features: star systems/sectors
+   - Network: hyperlanes
+   - Why second: simpler topology, weaker geometry pressure.
+
+3. **Planet on sphere**
+   - Domain: sphere with geodesic assumptions
+   - Features: cities/regions
+   - Network: long-distance routes
+   - Why later: introduces spherical geometry complexity.
+
+## Architectural decisions made for v0
+
+- **Pydantic-first contract** for domain/network/feature/layer/world schemas.
+- **Geometry and topology remain independent** in model shape, but linked by validation.
+- **Keep coordinates generic** (list of points) before introducing specialized geometry libs.
+- **Start deterministic generation** to enable reliable tests and CI stability.
+- **Visualization utility with matplotlib** for immediate sanity checks and demos.
+
+## Proposed implementation order
+
+1. Core models (`Domain`, `Feature`, `Network`, `Layer`, `World`, `Portal`)
+2. First generator: flat city with road grid + block polygons + directed road graph
+3. Plotting utility for layers
+4. Tests for schema constraints and end-to-end city generation
+5. Follow-up: spherical planet and galaxy graph adapters
+
+## Forward-compatibility notes
+
+- When we add `sphere_2d`, coordinate semantics should be explicit (lat/lon vs 3D unit vector).
+- Keep `properties` dictionaries for extensibility, but stabilize core key names via docs.
+- Future optional dependency: networkx/shapely only when needed, not in v0.
+- Portal mappings will eventually need richer references (feature subsets, transform metadata).

--- a/src/spatial_data_generation/__init__.py
+++ b/src/spatial_data_generation/__init__.py
@@ -1,0 +1,24 @@
+"""Spatial data generation package."""
+
+from spatial_data_generation.models import Layer, World
+from spatial_data_generation.scenarios import (
+    CitySpec,
+    GalaxySpec,
+    PlanetSpec,
+    build_city_layer,
+    build_galaxy_layer,
+    build_planet_layer,
+    build_reference_world,
+)
+
+__all__ = [
+    "CitySpec",
+    "GalaxySpec",
+    "PlanetSpec",
+    "Layer",
+    "World",
+    "build_city_layer",
+    "build_galaxy_layer",
+    "build_planet_layer",
+    "build_reference_world",
+]

--- a/src/spatial_data_generation/city_flat.py
+++ b/src/spatial_data_generation/city_flat.py
@@ -1,0 +1,8 @@
+"""Backward-compatible city scenario wrappers."""
+
+from spatial_data_generation.scenarios import CitySpec, build_city_layer
+
+
+def generate_flat_city_layer(layer_id: str, spec: CitySpec):
+    """Compat shim; delegates to the abstract scenario builder."""
+    return build_city_layer(layer_id, spec)

--- a/src/spatial_data_generation/models.py
+++ b/src/spatial_data_generation/models.py
@@ -1,0 +1,255 @@
+"""Core abstractions for multiscale spatial data generation.
+
+The schema follows the design in ``SPATIAL_DATA_OVERVIEW.md``:
+
+- Layer = (Domain, Features, Network)
+- World = (Layers, Portals)
+
+Geometry, topology, and hierarchy are modeled independently and composed at the
+layer/world level.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class DomainKind(str, Enum):
+    """Kinds of spatial domains (underlying spaces)."""
+
+    PLANE = "plane"
+    SPHERE = "sphere"
+    GRAPH = "graph"
+
+
+class GeometryType(str, Enum):
+    """Embedded geometry types for features."""
+
+    POINT = "point"
+    PATH = "path"
+    REGION = "region"
+
+
+class Domain(BaseModel):
+    """Metric space domain for a layer."""
+
+    kind: DomainKind
+    metric: str
+    dimension: int = Field(ge=1)
+    bounds: dict[str, list[float]] | None = None
+    atlas: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_domain(self) -> "Domain":
+        if self.kind == DomainKind.PLANE:
+            if self.dimension != 2:
+                raise ValueError("plane domains must have dimension=2")
+            if self.bounds is not None:
+                mins = self.bounds.get("min")
+                maxs = self.bounds.get("max")
+                if mins is None or maxs is None:
+                    raise ValueError("plane bounds must include min/max vectors")
+                if len(mins) != self.dimension or len(maxs) != self.dimension:
+                    raise ValueError("plane bounds must match domain dimension")
+                if any(lo >= hi for lo, hi in zip(mins, maxs, strict=True)):
+                    raise ValueError("each min bound must be < max bound")
+
+        if self.kind == DomainKind.SPHERE:
+            if self.dimension != 2:
+                raise ValueError("sphere domains must have dimension=2 (lat/lon)")
+            if self.metric.lower() not in {"geodesic", "haversine", "great_circle"}:
+                raise ValueError("sphere domains require a geodesic metric")
+
+        if self.kind == DomainKind.GRAPH and self.bounds is not None:
+            raise ValueError("graph domains should not define coordinate bounds")
+
+        return self
+
+
+class Geometry(BaseModel):
+    """Geometry embedded in a domain."""
+
+    type: GeometryType
+    coordinates: list[list[float]]
+
+    @field_validator("coordinates")
+    @classmethod
+    def non_empty_coordinates(cls, value: list[list[float]]) -> list[list[float]]:
+        if not value:
+            raise ValueError("coordinates cannot be empty")
+        return value
+
+
+class Feature(BaseModel):
+    """Semantic object embedded in a domain."""
+
+    id: str
+    kind: str
+    geometry: Geometry
+    properties: dict[str, Any] = Field(default_factory=dict)
+    style: dict[str, Any] = Field(default_factory=dict)
+
+
+class NetworkNode(BaseModel):
+    """Node in a traversal network."""
+
+    id: str
+    position: list[float] | None = None
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class NetworkEdge(BaseModel):
+    """Edge in a traversal network."""
+
+    source: str
+    target: str
+    cost: float = Field(default=1.0, gt=0)
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class Network(BaseModel):
+    """Topology over a layer domain/features."""
+
+    nodes: list[NetworkNode] = Field(default_factory=list)
+    edges: list[NetworkEdge] = Field(default_factory=list)
+    directed: bool = True
+
+    @model_validator(mode="after")
+    def validate_endpoints(self) -> "Network":
+        node_ids = {node.id for node in self.nodes}
+        for edge in self.edges:
+            if edge.source not in node_ids or edge.target not in node_ids:
+                raise ValueError(
+                    f"edge ({edge.source} -> {edge.target}) references unknown node"
+                )
+        return self
+
+
+class Layer(BaseModel):
+    """Layer = (Domain, Features, Network)."""
+
+    id: str
+    domain: Domain
+    features: list[Feature] = Field(default_factory=list)
+    network: Network | None = None
+
+    @model_validator(mode="after")
+    def validate_embeddings(self) -> "Layer":
+        mins = maxs = None
+        if self.domain.bounds is not None:
+            mins = self.domain.bounds.get("min")
+            maxs = self.domain.bounds.get("max")
+
+        for feature in self.features:
+            coords = feature.geometry.coordinates
+
+            if feature.geometry.type == GeometryType.POINT and len(coords) != 1:
+                raise ValueError(f"feature {feature.id}: point geometries must have 1 coordinate")
+            if feature.geometry.type == GeometryType.PATH and len(coords) < 2:
+                raise ValueError(f"feature {feature.id}: path geometries must have >=2 coordinates")
+            if feature.geometry.type == GeometryType.REGION and len(coords) < 3:
+                raise ValueError(f"feature {feature.id}: region geometries must have >=3 coordinates")
+
+            for point in coords:
+                if len(point) != self.domain.dimension:
+                    raise ValueError(
+                        f"feature {feature.id}: coordinate dimension {len(point)} != domain "
+                        f"dimension {self.domain.dimension}"
+                    )
+                if self.domain.kind == DomainKind.SPHERE:
+                    lat, lon = point
+                    if not (-90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0):
+                        raise ValueError(
+                            f"feature {feature.id}: sphere coords must be [lat, lon]"
+                        )
+                if mins is not None and maxs is not None:
+                    for val, lo, hi in zip(point, mins, maxs, strict=True):
+                        if not (lo <= val <= hi):
+                            raise ValueError(
+                                f"feature {feature.id}: coordinate {point} outside bounds"
+                            )
+
+        if self.network is not None:
+            for node in self.network.nodes:
+                if node.position is None:
+                    continue
+                if len(node.position) != self.domain.dimension:
+                    raise ValueError(
+                        f"node {node.id}: position dimension {len(node.position)} != "
+                        f"domain dimension {self.domain.dimension}"
+                    )
+
+        return self
+
+
+class Portal(BaseModel):
+    """Local mapping between subsets of two layers."""
+
+    id: str
+    source_layer_id: str
+    target_layer_id: str
+    source_feature_id: str | None = None
+    target_feature_id: str | None = None
+    mapping_kind: str = "local_map"
+    properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class World(BaseModel):
+    """World = (Layers, Portals) with portal hierarchy as DAG."""
+
+    layers: list[Layer]
+    portals: list[Portal] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_world(self) -> "World":
+        layer_by_id = {layer.id: layer for layer in self.layers}
+        edges: dict[str, set[str]] = {layer.id: set() for layer in self.layers}
+
+        for portal in self.portals:
+            if portal.source_layer_id not in layer_by_id:
+                raise ValueError(f"unknown source layer: {portal.source_layer_id}")
+            if portal.target_layer_id not in layer_by_id:
+                raise ValueError(f"unknown target layer: {portal.target_layer_id}")
+            edges[portal.source_layer_id].add(portal.target_layer_id)
+
+            if portal.source_feature_id is not None:
+                source_ids = {f.id for f in layer_by_id[portal.source_layer_id].features}
+                if portal.source_feature_id not in source_ids:
+                    raise ValueError(
+                        f"portal {portal.id} references unknown source feature "
+                        f"{portal.source_feature_id}"
+                    )
+
+            if portal.target_feature_id is not None:
+                target_ids = {f.id for f in layer_by_id[portal.target_layer_id].features}
+                if portal.target_feature_id not in target_ids:
+                    raise ValueError(
+                        f"portal {portal.id} references unknown target feature "
+                        f"{portal.target_feature_id}"
+                    )
+
+        visited: set[str] = set()
+        stack: set[str] = set()
+
+        def dfs(layer_id: str) -> bool:
+            if layer_id in stack:
+                return True
+            if layer_id in visited:
+                return False
+            visited.add(layer_id)
+            stack.add(layer_id)
+            for nxt in edges[layer_id]:
+                if dfs(nxt):
+                    return True
+            stack.remove(layer_id)
+            return False
+
+        for layer in self.layers:
+            if dfs(layer.id):
+                raise ValueError("portal hierarchy must be acyclic")
+
+        return self

--- a/src/spatial_data_generation/scenarios.py
+++ b/src/spatial_data_generation/scenarios.py
@@ -1,0 +1,210 @@
+"""Scenario builders that exercise the abstract spatial schema end-to-end."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+from spatial_data_generation.models import (
+    Domain,
+    DomainKind,
+    Feature,
+    Geometry,
+    GeometryType,
+    Layer,
+    Network,
+    NetworkEdge,
+    NetworkNode,
+    Portal,
+    World,
+)
+
+
+@dataclass(frozen=True)
+class CitySpec:
+    width: float = 100.0
+    height: float = 80.0
+    blocks_x: int = 4
+    blocks_y: int = 3
+
+
+@dataclass(frozen=True)
+class PlanetSpec:
+    lat_bands: int = 5
+    lon_bands: int = 8
+
+
+@dataclass(frozen=True)
+class GalaxySpec:
+    systems: int = 7
+
+
+def _grid_positions(length: float, count: int) -> list[float]:
+    if count < 2:
+        raise ValueError("grid count must be >= 2")
+    step = length / (count - 1)
+    return [i * step for i in range(count)]
+
+
+def build_city_layer(layer_id: str, spec: CitySpec) -> Layer:
+    x_lines = _grid_positions(spec.width, spec.blocks_x + 1)
+    y_lines = _grid_positions(spec.height, spec.blocks_y + 1)
+
+    features: list[Feature] = []
+    for i in range(spec.blocks_x):
+        for j in range(spec.blocks_y):
+            x0, x1 = x_lines[i], x_lines[i + 1]
+            y0, y1 = y_lines[j], y_lines[j + 1]
+            features.append(
+                Feature(
+                    id=f"district_{i}_{j}",
+                    kind="district",
+                    geometry=Geometry(
+                        type=GeometryType.REGION,
+                        coordinates=[[x0, y0], [x1, y0], [x1, y1], [x0, y1]],
+                    ),
+                    properties={"grid": [i, j]},
+                )
+            )
+
+    nodes: list[NetworkNode] = []
+    edges: list[NetworkEdge] = []
+    node_id_by_grid: dict[tuple[int, int], str] = {}
+
+    for i, x in enumerate(x_lines):
+        for j, y in enumerate(y_lines):
+            nid = f"cross_{i}_{j}"
+            node_id_by_grid[(i, j)] = nid
+            nodes.append(NetworkNode(id=nid, position=[x, y]))
+
+    for i in range(len(x_lines)):
+        for j in range(len(y_lines)):
+            if i + 1 < len(x_lines):
+                a = node_id_by_grid[(i, j)]
+                b = node_id_by_grid[(i + 1, j)]
+                c = x_lines[i + 1] - x_lines[i]
+                edges.extend([NetworkEdge(source=a, target=b, cost=c), NetworkEdge(source=b, target=a, cost=c)])
+            if j + 1 < len(y_lines):
+                a = node_id_by_grid[(i, j)]
+                b = node_id_by_grid[(i, j + 1)]
+                c = y_lines[j + 1] - y_lines[j]
+                edges.extend([NetworkEdge(source=a, target=b, cost=c), NetworkEdge(source=b, target=a, cost=c)])
+
+    return Layer(
+        id=layer_id,
+        domain=Domain(
+            kind=DomainKind.PLANE,
+            metric="euclidean",
+            dimension=2,
+            bounds={"min": [0.0, 0.0], "max": [spec.width, spec.height]},
+        ),
+        features=features,
+        network=Network(nodes=nodes, edges=edges, directed=True),
+    )
+
+
+def build_planet_layer(layer_id: str, spec: PlanetSpec) -> Layer:
+    latitudes = [(-60 + 120 * i / (spec.lat_bands - 1)) for i in range(spec.lat_bands)]
+    longitudes = [(-180 + 360 * j / spec.lon_bands) for j in range(spec.lon_bands)]
+
+    features: list[Feature] = []
+    nodes: list[NetworkNode] = []
+    edges: list[NetworkEdge] = []
+
+    for i, lat in enumerate(latitudes):
+        for j, lon in enumerate(longitudes):
+            city_id = f"city_{i}_{j}"
+            features.append(
+                Feature(
+                    id=city_id,
+                    kind="city",
+                    geometry=Geometry(type=GeometryType.POINT, coordinates=[[lat, lon]]),
+                    properties={"population_m": round(0.5 + ((i + j) % 5) * 0.7, 2)},
+                )
+            )
+            nodes.append(NetworkNode(id=city_id, position=[lat, lon]))
+
+    for i in range(spec.lat_bands):
+        for j in range(spec.lon_bands):
+            curr = f"city_{i}_{j}"
+            east = f"city_{i}_{(j + 1) % spec.lon_bands}"
+            if i + 1 < spec.lat_bands:
+                north = f"city_{i + 1}_{j}"
+                edges.append(NetworkEdge(source=curr, target=north, cost=1.0))
+                edges.append(NetworkEdge(source=north, target=curr, cost=1.0))
+            edges.append(NetworkEdge(source=curr, target=east, cost=1.0))
+            edges.append(NetworkEdge(source=east, target=curr, cost=1.0))
+
+    return Layer(
+        id=layer_id,
+        domain=Domain(kind=DomainKind.SPHERE, metric="geodesic", dimension=2),
+        features=features,
+        network=Network(nodes=nodes, edges=edges, directed=True),
+    )
+
+
+def build_galaxy_layer(layer_id: str, spec: GalaxySpec) -> Layer:
+    radius = 90.0
+    systems = []
+    for idx in range(spec.systems):
+        theta = (2 * math.pi * idx) / spec.systems
+        x = radius * math.cos(theta)
+        y = radius * math.sin(theta)
+        systems.append((idx, x, y))
+
+    features: list[Feature] = []
+    nodes: list[NetworkNode] = []
+    edges: list[NetworkEdge] = []
+    for idx, x, y in systems:
+        sid = f"system_{idx}"
+        features.append(
+            Feature(
+                id=sid,
+                kind="star_system",
+                geometry=Geometry(type=GeometryType.POINT, coordinates=[[x, y]]),
+            )
+        )
+        nodes.append(NetworkNode(id=sid, position=[x, y]))
+
+    for idx in range(spec.systems):
+        a = f"system_{idx}"
+        b = f"system_{(idx + 1) % spec.systems}"
+        c = f"system_{(idx + 2) % spec.systems}"
+        edges.append(NetworkEdge(source=a, target=b, cost=1.0, properties={"kind": "ring"}))
+        edges.append(NetworkEdge(source=a, target=c, cost=1.7, properties={"kind": "chord"}))
+
+    return Layer(
+        id=layer_id,
+        domain=Domain(
+            kind=DomainKind.PLANE,
+            metric="euclidean",
+            dimension=2,
+            bounds={"min": [-100.0, -100.0], "max": [100.0, 100.0]},
+        ),
+        features=features,
+        network=Network(nodes=nodes, edges=edges, directed=True),
+    )
+
+
+def build_reference_world() -> World:
+    galaxy = build_galaxy_layer("galaxy", GalaxySpec())
+    planet = build_planet_layer("planet_0", PlanetSpec())
+    city = build_city_layer("city_0_0", CitySpec())
+
+    return World(
+        layers=[galaxy, planet, city],
+        portals=[
+            Portal(
+                id="portal_system_to_planet",
+                source_layer_id="galaxy",
+                target_layer_id="planet_0",
+                source_feature_id="system_0",
+            ),
+            Portal(
+                id="portal_planet_city",
+                source_layer_id="planet_0",
+                target_layer_id="city_0_0",
+                source_feature_id="city_0_0",
+            ),
+        ],
+    )

--- a/src/spatial_data_generation/visualize.py
+++ b/src/spatial_data_generation/visualize.py
@@ -1,0 +1,84 @@
+"""Visualization helpers for layers with domain-specific renderers."""
+
+from __future__ import annotations
+
+import math
+
+import matplotlib.pyplot as plt
+
+from spatial_data_generation.models import DomainKind, GeometryType, Layer
+
+
+COLORS = {
+    "district": "#bfdbfe",
+    "city": "#f59e0b",
+    "star_system": "#a78bfa",
+}
+
+
+def _draw_plane_layer(ax, layer: Layer, show_network: bool) -> None:
+    for feature in layer.features:
+        coords = feature.geometry.coordinates
+        xs = [p[0] for p in coords]
+        ys = [p[1] for p in coords]
+        if feature.geometry.type == GeometryType.POINT:
+            ax.scatter(xs, ys, s=40, color=COLORS.get(feature.kind, "#111827"))
+        elif feature.geometry.type == GeometryType.PATH:
+            ax.plot(xs, ys, color="#4b5563", linewidth=1.6)
+        else:
+            ax.fill(xs, ys, facecolor=COLORS.get(feature.kind, "#cbd5e1"), edgecolor="#1f2937", alpha=0.45)
+
+    if show_network and layer.network:
+        pos = {n.id: n.position for n in layer.network.nodes if n.position is not None}
+        for edge in layer.network.edges:
+            src = pos.get(edge.source)
+            dst = pos.get(edge.target)
+            if src and dst:
+                ax.plot([src[0], dst[0]], [src[1], dst[1]], color="#ef4444", alpha=0.28, linewidth=0.9)
+
+    ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+
+
+def _draw_sphere_layer(ax, layer: Layer, show_network: bool) -> None:
+    # Coordinates are [lat, lon]; convert to radians for Mollweide plot.
+    feature_pos: dict[str, tuple[float, float]] = {}
+    for feature in layer.features:
+        lat, lon = feature.geometry.coordinates[0]
+        lon_r = math.radians(lon)
+        lat_r = math.radians(lat)
+        feature_pos[feature.id] = (lon_r, lat_r)
+        ax.scatter(lon_r, lat_r, s=22, alpha=0.85)
+
+    if show_network and layer.network:
+        pos = {n.id: (math.radians(n.position[1]), math.radians(n.position[0])) for n in layer.network.nodes if n.position}
+        for edge in layer.network.edges:
+            src = pos.get(edge.source)
+            dst = pos.get(edge.target)
+            if src and dst:
+                ax.plot([src[0], dst[0]], [src[1], dst[1]], color="#14b8a6", alpha=0.18, linewidth=0.7)
+
+    ax.grid(True, alpha=0.3)
+    ax.set_xlabel("longitude")
+    ax.set_ylabel("latitude")
+
+
+def plot_layer(layer: Layer, show_network: bool = True):
+    """Render a layer with an appropriate projection based on domain kind."""
+    if layer.domain.kind == DomainKind.SPHERE:
+        fig = plt.figure(figsize=(10, 5.5))
+        ax = fig.add_subplot(111, projection="mollweide")
+        _draw_sphere_layer(ax, layer, show_network)
+    else:
+        fig, ax = plt.subplots(figsize=(7, 7))
+        _draw_plane_layer(ax, layer, show_network)
+
+    ax.set_title(layer.id)
+    return fig, ax
+
+
+def save_layer_plot(layer: Layer, output_path: str, show_network: bool = True) -> None:
+    fig, _ = plot_layer(layer, show_network=show_network)
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)

--- a/test/spatial_data_generation/test_spatial_abstractions.py
+++ b/test/spatial_data_generation/test_spatial_abstractions.py
@@ -1,0 +1,91 @@
+import pytest
+from pydantic import ValidationError
+
+from spatial_data_generation.models import (
+    Domain,
+    DomainKind,
+    Feature,
+    Geometry,
+    GeometryType,
+    Layer,
+    Portal,
+    World,
+)
+from spatial_data_generation.scenarios import (
+    CitySpec,
+    GalaxySpec,
+    PlanetSpec,
+    build_city_layer,
+    build_galaxy_layer,
+    build_planet_layer,
+    build_reference_world,
+)
+
+
+def test_plane_bounds_validate_vector_shape():
+    with pytest.raises(ValidationError):
+        Domain(
+            kind=DomainKind.PLANE,
+            metric="euclidean",
+            dimension=2,
+            bounds={"min": [0.0], "max": [1.0, 1.0]},
+        )
+
+
+def test_layer_enforces_embedding_dimension():
+    with pytest.raises(ValidationError):
+        Layer(
+            id="bad",
+            domain=Domain(kind=DomainKind.PLANE, metric="euclidean", dimension=2),
+            features=[
+                Feature(
+                    id="f0",
+                    kind="poi",
+                    geometry=Geometry(type=GeometryType.POINT, coordinates=[[1.0, 2.0, 3.0]]),
+                )
+            ],
+        )
+
+
+def test_world_portal_hierarchy_must_be_acyclic():
+    a = build_city_layer("a", CitySpec())
+    b = build_city_layer("b", CitySpec())
+    with pytest.raises(ValidationError):
+        World(
+            layers=[a, b],
+            portals=[
+                Portal(id="p1", source_layer_id="a", target_layer_id="b"),
+                Portal(id="p2", source_layer_id="b", target_layer_id="a"),
+            ],
+        )
+
+
+def test_multiscale_reference_world_e2e():
+    world = build_reference_world()
+
+    assert len(world.layers) == 3
+    assert len(world.portals) == 2
+
+    galaxy = next(layer for layer in world.layers if layer.id == "galaxy")
+    planet = next(layer for layer in world.layers if layer.id == "planet_0")
+    city = next(layer for layer in world.layers if layer.id == "city_0_0")
+
+    assert galaxy.domain.kind == DomainKind.PLANE
+    assert planet.domain.kind == DomainKind.SPHERE
+    assert city.domain.kind == DomainKind.PLANE
+
+    assert galaxy.network is not None and len(galaxy.network.nodes) == GalaxySpec().systems
+    assert planet.network is not None and len(planet.network.nodes) == PlanetSpec().lat_bands * PlanetSpec().lon_bands
+
+    expected_city_nodes = (CitySpec().blocks_x + 1) * (CitySpec().blocks_y + 1)
+    assert city.network is not None and len(city.network.nodes) == expected_city_nodes
+
+
+def test_sphere_requires_geodesic_metric():
+    with pytest.raises(ValidationError):
+        Domain(kind=DomainKind.SPHERE, metric="euclidean", dimension=2)
+
+
+def test_scenario_builders_construct_valid_layers():
+    assert build_galaxy_layer("g", GalaxySpec()).id == "g"
+    assert build_planet_layer("p", PlanetSpec()).id == "p"


### PR DESCRIPTION
### Motivation

- The previous spatial slice overfit city mechanics too early instead of following the abstraction in `SPATIAL_DATA_OVERVIEW.md`, so the change re-centers the implementation on a minimal, extensible contract for multiscale spatial data. 
- The goal is to express geometry, topology, and hierarchy independently so scenario builders for city/planet/galaxy can share the same high-level model and validators.

### Description

- Replace the earlier city-centric models with an abstraction-first Pydantic schema in `src/spatial_data_generation/models.py` that defines `Domain`, `Geometry`, `Feature`, `Network`, `Layer`, `Portal`, and `World` and enforces domain, embedding, network endpoint, and portal-DAG validations. 
- Add unified scenario builders in `src/spatial_data_generation/scenarios.py` providing `build_city_layer`, `build_planet_layer`, `build_galaxy_layer`, and `build_reference_world` to exercise the schema end-to-end. 
- Add domain-aware visualization in `src/spatial_data_generation/visualize.py` with planar rendering and Mollweide projection for spherical domains, plus runnable examples `examples/spatial_data_generation/multiscale_world_example.py` and `examples/spatial_data_generation/city_flat_example.py`. 
- Keep a backward-compatible shim `src/spatial_data_generation/city_flat.py`, update package exports in `src/spatial_data_generation/__init__.py`, and replace the old city-only tests with `test/spatial_data_generation/test_spatial_abstractions.py` which checks abstraction-level invariants and multiscale composition. 

### Testing

- Ran `PYTHONPATH=src pytest -q test/spatial_data_generation/test_spatial_abstractions.py` and all tests passed (`6 passed`).
- Executed the multiscale example with `PYTHONPATH=src python examples/spatial_data_generation/multiscale_world_example.py` which saved `galaxy.png`, `planet_0.png`, and `city_0_0.png` successfully. 
- Ran the city example with `PYTHONPATH=src python examples/spatial_data_generation/city_flat_example.py` which generated the sample city image and printed the generated layer summary successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf3742fec832e90546ad468702116)